### PR TITLE
[추가] 일반 버튼, 헤더 버튼 컴포넌트 생성 (2023.03.10 왕지호)

### DIFF
--- a/frontend/src/components/UI/Button.js
+++ b/frontend/src/components/UI/Button.js
@@ -1,0 +1,94 @@
+import styled, { css } from 'styled-components';
+
+const VARIANTS = {
+  inputbtn: css`
+    --btn-color: var(--color-light-0);
+    --btn-bg-color: var(--color-dark-0);
+    --btn-hover-bg-color: var(--color-secondary);
+    --btn-box-width: 200px;
+    --btn-box-height: 40px;
+  `,
+  edit: css`
+    --btn-color: var(--color-light-0);
+    --btn-bg-color: var(--color-tertiary);
+    --btn-hover-bg-color: var(--color-tertiary);
+    --btn-box-width: 135px;
+    --btn-box-height: 45px;
+  `,
+  follow: css`
+    --btn-color: var(--color-light-0);
+    --btn-bg-color: var(--color-secondary);
+    --btn-hover-bg-color: var(--color-secondary);
+    --btn-box-width: 135px;
+    --btn-box-height: 45px;
+  `,
+  unfollow: css`
+    --btn-color: var(--color-light-0);
+    --btn-bg-color: var(--color-dark-0);
+    --btn-hover-bg-color: var(--color-tertiary);
+    --btn-box-width: 135px;
+    --btn-box-height: 45px;
+  `,
+  finish: css`
+    --btn-color: var(--color-light-0);
+    --btn-bg-color: var(--color-primary);
+    --btn-hover-bg-color: var(--color-primary);
+    --btn-box-width: 135px;
+    --btn-box-height: 45px;
+  `,
+  upload: css`
+    --btn-color: var(--color-light-0);
+    --btn-bg-color: var(--color-dark-0);
+    --btn-hover-bg-color: var(--color-primary);
+    --btn-box-width: 135px;
+    --btn-box-height: 45px;
+  `,
+  cancel: css`
+    --btn-color: var(--color-light-0);
+    --btn-bg-color: var(--color-dark-0);
+    --btn-hover-bg-color: var(--color-secondary);
+    --btn-box-width: 135px;
+    --btn-box-height: 45px;
+  `,
+  location: css`
+    --btn-color: var(--color-light-0);
+    --btn-bg-color: var(--color-dark-0);
+    --btn-hover-bg-color: var(--color-secondary);
+    --btn-box-width: 107px;
+    --btn-box-height: 36px;
+  `,
+};
+
+const StyledButton = styled.button`
+  ${({ variant }) => VARIANTS[variant]}
+
+  font-size: 16px;
+  font-weight: 500;
+  width: var(--btn-box-width);
+  height: var(--btn-box-height);
+  color: var(--btn-color);
+  background-color: var(--btn-bg-color);
+  border: 1.5px solid var(--color-dark-0);
+  border-radius: 5px;
+  transition: all 140ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+
+  &:hover {
+    color: var(--color-light-0);
+    background-color: var(--btn-hover-bg-color);
+    border: 1.5px solid var(--color-dark-0);
+    box-shadow: 3px 3px 0 0 var(--color-dark-0);
+    -webkit-transform: translate(-0.25rem, -0.25rem);
+    -ms-transform: translate(-0.25rem, -0.25rem);
+    transform: translate(-0.25rem, -0.25rem);
+  }
+`;
+
+function Button({ variant = 'edit', tag = 'button', children }) {
+  return (
+    <StyledButton variant={variant} as={tag}>
+      {children}
+    </StyledButton>
+  );
+}
+
+export default Button;

--- a/frontend/src/components/UI/HeaderButton.js
+++ b/frontend/src/components/UI/HeaderButton.js
@@ -1,0 +1,71 @@
+import styled, { css } from 'styled-components';
+
+const VARIANTS = {
+  login: css`
+    --btn-color: var(--color-light-0);
+    --btn-bg-color: var(--color-dark-0);
+    --btn-hover-bg-color: var(--color-secondary);
+    --btn-box-width: 150px;
+    --btn-box-height: 69px;
+    --btn-border-bottom: 1.5px solid var(--color-dark-0);
+  `,
+  logout: css`
+    --btn-color: var(--color-dark-0);
+    --btn-bg-color: var(--color-light-0);
+    --btn-hover-bg-color: var(--color-tertiary);
+    --btn-box-width: 150px;
+    --btn-box-height: 69px;
+    --btn-box-radius: 0 10px 0 0;
+    --btn-border-left: 1.5px solid var(--color-dark-0);
+    --btn-border-bottom: 1.5px solid var(--color-dark-0);
+  `,
+  mypage: css`
+    --btn-color: var(--color-light-0);
+    --btn-bg-color: var(--color-dark-0);
+    --btn-hover-bg-color: var(--color-secondary);
+    --btn-box-width: 150px;
+    --btn-box-height: 69px;
+    --btn-border-bottom: 1.5px solid var(--color-dark-0);
+  `,
+  write: css`
+    --btn-color: var(--color-dark-0);
+    --btn-bg-color: var(--color-light-0);
+    --btn-hover-bg-color: var(--color-primary);
+    --btn-box-width: 150px;
+    --btn-box-height: 69px;
+    --btn-border-left: 1.5px solid var(--color-dark-0);
+    --btn-border-bottom: 1.5px solid var(--color-dark-0);
+  `,
+};
+
+const StyledButton = styled.button`
+  ${({ variant }) => VARIANTS[variant]}
+
+  font-size: 16px;
+  font-weight: 500;
+  width: var(--btn-box-width);
+  height: var(--btn-box-height);
+  color: var(--btn-color);
+  background-color: var(--btn-bg-color);
+  border-left: var(--btn-border-left);
+  border-bottom: var(--btn-border-bottom);
+  border-radius: var(--btn-box-radius);
+
+  &:hover {
+    color: var(--color-light-0);
+    background-color: var(--btn-hover-bg-color);
+    border: var(--btn-border);
+    border-left: var(--btn-border-left);
+    border-bottom: var(--btn-border-bottom);
+  }
+`;
+
+function HeaderButton({ variant = 'write', tag = 'button', children }) {
+  return (
+    <StyledButton variant={variant} as={tag}>
+      {children}
+    </StyledButton>
+  );
+}
+
+export default HeaderButton;


### PR DESCRIPTION
## 개발내용
- 버튼 컴포넌트 추가
- 헤더 버튼 컴포넌트 추가

<img width="767" alt="image" src="https://user-images.githubusercontent.com/115687422/224335917-188e782a-3448-46ea-8afa-4b8e66242fe8.png">


## 고민사항
- 결이 다른거 같아서 헤더에 위치한 버튼이랑 일반 버튼이랑 나눠서 컴포넌트 작업을 했는데 과연 이게 맞는지, 합치는게 맞는지...