### PR TITLE
[추가] 게시글에 많이 태그 된 추천장소리스트 반환 (위치 필터링)

### DIFF
--- a/backend/src/main/java/com/mybuddy/amenity/controller/AmenityController.java
+++ b/backend/src/main/java/com/mybuddy/amenity/controller/AmenityController.java
@@ -58,9 +58,8 @@ public class AmenityController {
     public ResponseEntity<ApiSingleResponse> getRecommendAmenities(@RequestParam(name = "state") String state,
                                                                    @RequestParam(name = "region") String region) {
 
-        List<Amenity> amenityList = amenityService.getRecommendAmenities(state,region);
-        List<AmenityResponseDto> recommendAmenities = amenityMapper.AmenityListToAmenityResponseDto(amenityList);
-        ApiSingleResponse response = new ApiSingleResponse(HttpStatus.OK,"지역에서 추천하는 장소 리스트입니다.", recommendAmenities);
+        List<AmenityResponseDto> amenityList = amenityService.getRecommendAmenities(state,region);
+        ApiSingleResponse response = new ApiSingleResponse(HttpStatus.OK,"지역에서 추천하는 장소 리스트입니다.", amenityList);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/mybuddy/amenity/dto/AmenityResponseDto.java
+++ b/backend/src/main/java/com/mybuddy/amenity/dto/AmenityResponseDto.java
@@ -12,4 +12,6 @@ public class AmenityResponseDto {
     private String address;
     private Double longitude;
     private Double latitude;
+
+    private Long bulletinPostCount;
 }

--- a/backend/src/main/java/com/mybuddy/amenity/repository/AmenityCustomRepository.java
+++ b/backend/src/main/java/com/mybuddy/amenity/repository/AmenityCustomRepository.java
@@ -1,5 +1,6 @@
 package com.mybuddy.amenity.repository;
 
+import com.mybuddy.amenity.dto.AmenityResponseDto;
 import com.mybuddy.amenity.entity.Amenity;
 
 import java.util.List;
@@ -10,5 +11,5 @@ public interface AmenityCustomRepository {
 
     List<Amenity> findByBulletinPostId(Long bulletinPostId);
 
-    List<Amenity> findByStateRegion(String state, String region);
+    List<AmenityResponseDto> findByStateRegion(String state, String region);
 }

--- a/backend/src/main/java/com/mybuddy/amenity/service/AmenityService.java
+++ b/backend/src/main/java/com/mybuddy/amenity/service/AmenityService.java
@@ -1,6 +1,7 @@
 package com.mybuddy.amenity.service;
 
 import com.mybuddy.amenity.dto.AmenityCreateDto;
+import com.mybuddy.amenity.dto.AmenityResponseDto;
 import com.mybuddy.amenity.entity.Amenity;
 import com.mybuddy.amenity.mapper.AmenityMapper;
 import com.mybuddy.amenity.repository.AmenityRepository;
@@ -50,8 +51,9 @@ public class AmenityService {
     }
 
     @Transactional
-    public List<Amenity> getRecommendAmenities(String state, String region){
-        List<Amenity> recommendAmenities = amenityRepository.findByStateRegion(state,region);
+    public List<AmenityResponseDto> getRecommendAmenities(String state, String region){
+
+        List<AmenityResponseDto> recommendAmenities = amenityRepository.findByStateRegion(state,region);
         return recommendAmenities;
     }
 }


### PR DESCRIPTION
게시글에 많이 태그 된 추천장소리스트 반환 (위치 필터링)을 적용했습니다. 
요청시 반환하는 json 정보는 다음과 같습니다. 

```json
{
    "code": "200",
    "message": "지역에서 추천하는 장소 리스트입니다.",
    "data": [
        {
            "amenityId": 2,
            "addressId": 1472202212355221,
            "amenityName": "강아지놀이터",
            "address": "서울 광진구 어딘가 주소입니다.",
            "longitude": 126.12834637823106,
            "latitude": 126.12834637823106,
            "bulletinPostCount": 18
        },
        {
            "amenityId": 1,
            "addressId": 1472202213554222321,
            "amenityName": "어딘가 장소인데 뭐라하지",
            "address": "서울 광진구 어딘가 주소입니다.",
            "longitude": 126.57647863723106,
            "latitude": 126.57647863723106,
            "bulletinPostCount": 5
        }
    ]
}

```