### PR TITLE
[추가/수정] #42 Member 관련 테스트 추가 / Service 메서드 로직 수정 (2023.03.11 강지후)

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -1,0 +1,108 @@
+= My Buddy
+:sectnums:
+:toc: left
+:toclevels: 4
+:toc-title: API Specification
+:source-highlighter: prettify
+
+== 회원
+=== 회원 등록
+.curl-request
+include::{snippets}/Post-Member/curl-request.adoc[]
+
+.http-request
+include::{snippets}/Post-Member/http-request.adoc[]
+
+.request-fields
+include::{snippets}/Post-Member/request-part-createDto-fields.adoc[]
+
+.request-part
+include::{snippets}/Post-Member/request-parts.adoc[]
+
+.http-response
+include::{snippets}/Post-Member/http-response.adoc[]
+
+.response-header
+include::{snippets}/Post-Member/response-headers.adoc[]
+
+////
+=== 회원 수정
+.curl-request
+include::{snippets}/Patch-Member/curl-request.adoc[]
+
+.http-request
+include::{snippets}/Patch-Member/http-request.adoc[]
+
+// Bearer token 관련 (추후 추가)
+// .request-headers
+// include::{snippets}/Patch-Member/request-headers.adoc[]
+
+.request-path-parameters
+include::{snippets}/Patch-Member/path-parameters.adoc[]
+
+.request-fields
+include::{snippets}/Patch-Member/request-part-patchDto-fields.adoc[]
+
+.request-part
+include::{snippets}/Patch-Member/request-parts.adoc[]
+
+.http-response
+include::{snippets}/Patch-Member/http-response.adoc[]
+////
+
+=== 회원 상세 조회
+.curl-request
+include::{snippets}/Get-Member/curl-request.adoc[]
+
+.http-request
+include::{snippets}/Get-Member/http-request.adoc[]
+
+.request-path-parameters
+include::{snippets}/Get-Member/path-parameters.adoc[]
+
+// Bearer token 관련 (추후 추가)
+// .request-headers
+// include::{snippets}/Get-Member/request-headers.adoc[]
+
+.http-response
+include::{snippets}/Get-Member/http-response.adoc[]
+
+.response-fields
+include::{snippets}/Get-Member/response-fields.adoc[]
+
+=== 회원 리스트 조회 (운영자용)
+.curl-request
+include::{snippets}/Get-Members-for-Admin/curl-request.adoc[]
+
+.http-request
+include::{snippets}/Get-Members-for-Admin/http-request.adoc[]
+
+.request-query-parameters
+include::{snippets}/Get-Members-for-Admin/request-parameters.adoc[]
+
+// Bearer token 관련 (추후 추가)
+// .request-headers
+// include::{snippets}/Get-Member/request-headers.adoc[]
+
+.http-response
+include::{snippets}/Get-Members-for-Admin/http-response.adoc[]
+
+.response-fields
+include::{snippets}/Get-Members-for-Admin/response-fields.adoc[]
+
+=== 회원 탈퇴
+.curl-request
+include::{snippets}/Delete-Member/curl-request.adoc[]
+
+.http-request
+include::{snippets}/Delete-Member/http-request.adoc[]
+
+// Bearer token 관련 (추후 추가)
+// .request-headers
+// include::{snippets}/Delete-Member/request-headers.adoc[]
+
+.request-path-parameters
+include::{snippets}/Delete-Member/path-parameters.adoc[]
+
+.http-response
+include::{snippets}/Delete-Member/http-response.adoc[]

--- a/backend/src/main/java/com/mybuddy/member/controller/MemberController.java
+++ b/backend/src/main/java/com/mybuddy/member/controller/MemberController.java
@@ -36,7 +36,7 @@ public class MemberController {
     private final MemberMapper mapper;
 
     @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-    public ResponseEntity<ApiSingleResponse> postMember(@Valid @RequestPart MemberCreateDto createDto,
+    public ResponseEntity<ApiSingleResponse> createMember(@Valid @RequestPart MemberCreateDto createDto,
                                                         @RequestPart(required = false) MultipartFile profileImage) {
         Member member = memberService.createMember(mapper.memberCreateDtoToMember(createDto), profileImage);
 
@@ -66,7 +66,7 @@ public class MemberController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiSingleResponse> getMemberList(@Positive @RequestParam int page,
+    public ResponseEntity<ApiMultiResponse> getMemberList(@Positive @RequestParam int page,
                                                            @Positive @RequestParam int size) {
         Page<Member> pageMembers = memberService.getMemberList(page - 1, size);
         List<Member> obtainedMembers = pageMembers.getContent();

--- a/backend/src/main/java/com/mybuddy/member/controller/MemberController.java
+++ b/backend/src/main/java/com/mybuddy/member/controller/MemberController.java
@@ -40,10 +40,10 @@ public class MemberController {
                                                         @RequestPart(required = false) MultipartFile profileImage) {
         Member member = memberService.createMember(mapper.memberCreateDtoToMember(createDto), profileImage);
 
-        URI location = UriMaker.getUri(MEMBER_DEFAULT_URL, member.getMemberId());
+        URI uriLocation = UriMaker.getUri(MEMBER_DEFAULT_URL, member.getMemberId());
         ApiSingleResponse response = new ApiSingleResponse(HttpStatus.CREATED, "회원이 생성되었습니다.");
 
-        return ResponseEntity.created(location).body(response);
+        return ResponseEntity.created(uriLocation).body(response);
     }
 
     @PatchMapping(value = "/{member-id}",

--- a/backend/src/main/java/com/mybuddy/member/dto/MemberPatchDto.java
+++ b/backend/src/main/java/com/mybuddy/member/dto/MemberPatchDto.java
@@ -12,15 +12,15 @@ public class MemberPatchDto {
 
     private String dogName;
 
-    private String location;
+    private String address;
 
     private String aboutMe;
 
     @Builder
-    public MemberPatchDto(String nickname, String dogName, String location, String aboutMe) {
+    public MemberPatchDto(String nickname, String dogName, String address, String aboutMe) {
         this.nickname = nickname;
         this.dogName = dogName;
-        this.location = location;
+        this.address = address;
         this.aboutMe = aboutMe;
     }
 }

--- a/backend/src/main/java/com/mybuddy/member/entity/Member.java
+++ b/backend/src/main/java/com/mybuddy/member/entity/Member.java
@@ -6,6 +6,7 @@ import javax.persistence.*;
 
 import com.mybuddy.bulletin_post.entity.BulletinPost;
 import com.mybuddy.comment.entity.Comment;
+import com.mybuddy.global.audit.Auditable;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,7 +15,7 @@ import lombok.Setter;
 @Entity
 @NoArgsConstructor
 @Getter
-public class Member {
+public class Member extends Auditable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/mybuddy/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/mybuddy/member/repository/MemberRepository.java
@@ -1,10 +1,15 @@
 package com.mybuddy.member.repository;
 
+
 import com.mybuddy.member.entity.Member;
+import com.mybuddy.member.entity.Member.MemberStatus;
+
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByMemberIdAndMemberStatusIs(Long memberId, MemberStatus memberStatus);
 }

--- a/backend/src/main/java/com/mybuddy/member/service/MemberServiceImpl.java
+++ b/backend/src/main/java/com/mybuddy/member/service/MemberServiceImpl.java
@@ -2,8 +2,11 @@ package com.mybuddy.member.service;
 
 //import com.mybuddy.global.auth.utils.MemberAuthorityUtils;
 
+import com.mybuddy.global.exception.LogicException;
+import com.mybuddy.global.exception.LogicExceptionCode;
 import com.mybuddy.global.storage.StorageService;
 import com.mybuddy.member.entity.Member;
+import com.mybuddy.member.entity.Member.MemberStatus;
 import com.mybuddy.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 //import org.springframework.security.crypto.password.PasswordEncoder;
@@ -14,9 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Transactional
 @Service
@@ -88,7 +89,7 @@ public class MemberServiceImpl implements MemberService {
     public void deleteMember(Long memberId) {
         Member obtainedMember = findExistMemberById(memberId);
 
-        obtainedMember.setMemberStatus(Member.MemberStatus.DELETED);
+        obtainedMember.setMemberStatus(MemberStatus.DELETED);
 
         memberRepository.save(obtainedMember);
     }
@@ -98,19 +99,16 @@ public class MemberServiceImpl implements MemberService {
         Optional<Member> optionalMember = memberRepository.findByEmail(email);
 
         if (optionalMember.isPresent())
-            throw new RuntimeException();
+            throw new LogicException(LogicExceptionCode.MEMBER_ALREADY_EXISTS);
     }
 
     @Override
     public Member findExistMemberById(Long memberId) {
-        Optional<Member> optionalMember = memberRepository.findById(memberId);
+        Optional<Member> optionalMember = memberRepository
+                .findByMemberIdAndMemberStatusIs(memberId, MemberStatus.ACTIVE);
 
         Member obtainedMember = optionalMember
-                .orElseThrow(() -> new RuntimeException());
-
-        if (obtainedMember.getMemberStatus() == Member.MemberStatus.DELETED) {
-            throw new RuntimeException();
-        }
+                .orElseThrow(() -> new LogicException(LogicExceptionCode.MEMBER_NOT_FOUND));
 
         return obtainedMember;
     }

--- a/backend/src/test/java/com/mybuddy/global/config/TestConfig.java
+++ b/backend/src/test/java/com/mybuddy/global/config/TestConfig.java
@@ -1,0 +1,20 @@
+package com.mybuddy.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@TestConfiguration
+public class TestConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/backend/src/test/java/com/mybuddy/global/mockdata/MockTestData.java
+++ b/backend/src/test/java/com/mybuddy/global/mockdata/MockTestData.java
@@ -1,0 +1,124 @@
+package com.mybuddy.global.mockdata;
+
+import com.mybuddy.member.dto.*;
+import com.mybuddy.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+
+public class MockTestData {
+
+    public static class MockMember {
+
+        public static Member getMember() {
+            return Member.builder()
+                    .memberId(1L)
+                    .email("kimcoding@mybuddy.com")
+                    .password("asdf1234")
+                    .nickname("김코딩")
+                    .aboutMe("왕밤톨입니다.")
+                    .dogName("왕밤톨")
+                    .dogGender(Member.DogGender.MALE)
+                    .profileUrl("www.mybuddy.com/bamtol-the-king.png")
+                    .address("서울시 강북구")
+                    .build();
+        }
+
+        public static MemberCreateDto getMemberCreateDto() {
+            return MemberCreateDto.builder()
+                    .email("kimcoding@mybuddy.com")
+                    .password("asdf1234")
+                    .nickname("김코딩")
+                    .dogName("왕밤톨")
+                    .dogGender(Member.DogGender.MALE)
+                    .build();
+        }
+
+        public static MemberPatchDto getMemberPatchDto() {
+            return MemberPatchDto.builder()
+                    .nickname("김코딩")
+                    .dogName("왕밤톨")
+                    .address("서울시 강북구")
+                    .aboutMe("왕밤톨입니다.")
+                    .build();
+        }
+
+        public static List<MyBulletinPostDto> getMyBulletinPostDtos() {
+            MyBulletinPostDto bulletinPostDto1 = MyBulletinPostDto.builder()
+                    .bulletinPostId(1L)
+                    .photoUrl("www.mybuddy.com/another-bamtol1.png")
+                    .build();
+
+            MyBulletinPostDto bulletinPostDto2 = MyBulletinPostDto.builder()
+                    .bulletinPostId(2L)
+                    .photoUrl("www.mybuddy.com/another-bamtol2.png")
+                    .build();
+
+            return List.of(bulletinPostDto1, bulletinPostDto2);
+        }
+
+        public static List<MyAmenityDto> getMyAmenityDtos() {
+            MyAmenityDto amenityDto1 = MyAmenityDto.builder()
+                    .amenityId(1L)
+                    .amenityName("애견카페1")
+                    .address("서울시 강북구 xx")
+                    .photoUrl("www.dog-cafe1.com/map.png")
+                    .build();
+
+            MyAmenityDto amenityDto2 = MyAmenityDto.builder()
+                    .amenityId(2L)
+                    .amenityName("애견카페2")
+                    .address("서울시 강북구 xx")
+                    .photoUrl("www.dog-cafe2.com/map.png")
+                    .build();
+
+            return List.of(amenityDto1, amenityDto2);
+        }
+
+        public static MemberResponseDto getMemberResponseDto() {
+            return MemberResponseDto.builder()
+                    .nickname("김코딩")
+                    .dogName("왕밤톨")
+                    .dogGender(com.mybuddy.member.entity.Member.DogGender.MALE)
+                    .aboutMe("왕밤톨입니다.")
+                    .followerNumber(null)
+                    .followeeNumber(null)
+                    .profileUrl("www.mybuddy.com/bamtol-the-king.png")
+                    .myBulletinPostDtos(getMyBulletinPostDtos())
+                    .myAmenityDtos(getMyAmenityDtos())
+                    .build();
+        }
+
+        public static List<MemberListResponseDto> getMemberListResponseDtos() {
+            MemberListResponseDto listResponseDto1 = MemberListResponseDto.builder()
+                    .nickname("김코딩")
+                    .dogName("왕밤톨")
+                    .followerNumber(null)
+                    .followeeNumber(null)
+                    .profileUrl("www.mybuddy.com/bamtol-the-king.png")
+                    .build();
+
+            MemberListResponseDto listResponseDto2 = MemberListResponseDto.builder()
+                    .nickname("홍길동")
+                    .dogName("뭉치")
+                    .followerNumber(null)
+                    .followeeNumber(null)
+                    .profileUrl("www.mybuddy.com/ordinary-dog.png")
+                    .build();
+
+            return List.of(listResponseDto1, listResponseDto2);
+        }
+
+        public static Page<Member> getPageMembers() {
+            Member member1 = new Member();
+            Member member2 = new Member();
+            List<Member> members = List.of(member1, member2);
+
+            return new PageImpl<>(members, PageRequest.of(0, 10,
+                    Sort.by("memberId").descending()), members.size());
+        }
+    }
+}

--- a/backend/src/test/java/com/mybuddy/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/mybuddy/member/controller/MemberControllerTest.java
@@ -1,0 +1,447 @@
+package com.mybuddy.member.controller;
+
+import com.google.gson.Gson;
+import com.mybuddy.global.mockdata.MockTestData;
+import com.mybuddy.member.dto.*;
+import com.mybuddy.member.entity.Member;
+import com.mybuddy.member.mapper.MemberMapper;
+import com.mybuddy.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.constraints.ConstraintDescriptions;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(MemberController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureRestDocs
+//@WithMockUser(username = "kimcoding@mybuddy.com", roles = {"USER"})
+public class MemberControllerTest {
+
+    private final String MEMBER_DEFAULT_URL = "/api/v1/members";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberService memberService;
+
+    @MockBean
+    private MemberMapper mapper;
+
+    @Autowired
+    private Gson gson;
+
+    @DisplayName("회원 등록")
+    @Test
+    public void createMemberTest() throws Exception {
+        // Given
+        String content = gson.toJson(MockTestData.MockMember.getMemberCreateDto());
+
+        MockMultipartFile createDto = new MockMultipartFile("createDto", null,
+                MediaType.APPLICATION_JSON_VALUE, content.getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile profileImage = new MockMultipartFile("profileImage", "image.png",
+                MediaType.IMAGE_PNG_VALUE, "image".getBytes(StandardCharsets.UTF_8));
+
+        given(mapper.memberCreateDtoToMember(Mockito.any(MemberCreateDto.class)))
+                .willReturn(new Member());
+        given(memberService.createMember(Mockito.any(Member.class), Mockito.any(MultipartFile.class)))
+                .willReturn(MockTestData.MockMember.getMember());
+
+        ConstraintDescriptions createMemberConstraints =
+                new ConstraintDescriptions(MemberCreateDto.class);
+        List<String> emailDescriptions = createMemberConstraints.descriptionsForProperty("email");
+        List<String> passwordDescriptions = createMemberConstraints.descriptionsForProperty("password");
+        List<String> nicknameDescriptions = createMemberConstraints.descriptionsForProperty("nickname");
+        List<String> dogNameDescriptions = createMemberConstraints.descriptionsForProperty("dogName");
+        List<String> dogGenderDescriptions = createMemberConstraints.descriptionsForProperty("dogGender");
+
+        // When
+        ResultActions actions =
+                mockMvc.perform(
+                        multipart(MEMBER_DEFAULT_URL)
+                                .file(createDto)
+                                .file(profileImage)
+                                //.with(csrf())
+                                .contentType(MediaType.MULTIPART_FORM_DATA)
+                );
+
+        // Then
+        actions
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", is(startsWith(MEMBER_DEFAULT_URL))))
+                .andDo(document("Post-Member",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestPartBody(
+                                "createDto"
+                        ),
+                        requestPartFields("createDto",
+                                List.of(
+                                        fieldWithPath("email")
+                                                .type(JsonFieldType.STRING)
+                                                .description("이메일")
+                                                .attributes(key("constraints").value(emailDescriptions)),
+                                        fieldWithPath("password")
+                                                .type(JsonFieldType.STRING)
+                                                .description("암호")
+                                                .attributes(key("constraints").value(passwordDescriptions)),
+                                        fieldWithPath("nickname")
+                                                .type(JsonFieldType.STRING)
+                                                .description("견주 닉네임")
+                                                .attributes(key("constraints").value(nicknameDescriptions)),
+                                        fieldWithPath("dogName")
+                                                .type(JsonFieldType.STRING)
+                                                .description("강아지 이름")
+                                                .attributes(key("constraints").value(dogNameDescriptions)),
+                                        fieldWithPath("dogGender")
+                                                .type(JsonFieldType.STRING)
+                                                .description("강아지 성별")
+                                                .attributes(key("constraints").value(dogGenderDescriptions))
+                                )),
+                        relaxedRequestParts(
+                                partWithName("profileImage").description("첨부 파일")
+                        ),
+                        responseHeaders(
+                                headerWithName(HttpHeaders.LOCATION).description("Location header. 등록된 리소스의 URI")
+                        )));
+    }
+
+    // 사진 업로드 관련하여 patch를 사용할지 여부 결정 후 주석 제거.
+    /*@DisplayName("회원 정보 수정")
+    @Test
+    public void patchMemberTest() throws Exception {
+        // Given
+        String content = gson.toJson(MockTestData.MockMember.getMemberPatchDto());
+
+        MockMultipartFile patchDto = new MockMultipartFile("patchDto", null,
+                MediaType.APPLICATION_JSON_VALUE, content.getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile profileImage = new MockMultipartFile("profileImage", "image.png",
+                MediaType.IMAGE_PNG_VALUE, "image" .getBytes(StandardCharsets.UTF_8));
+
+        given(mapper.memberPatchDtoToMember(Mockito.any(MemberPatchDto.class)))
+                .willReturn(new Member());
+        given(memberService.updateMember(Mockito.any(Member.class), Mockito.any(MultipartFile.class)))
+                .willReturn(MockTestData.MockMember.getMember());
+
+        ConstraintDescriptions patchMemberConstraints =
+                new ConstraintDescriptions(MemberCreateDto.class);
+        List<String> nicknameDescriptions = patchMemberConstraints.descriptionsForProperty("nickname");
+        List<String> dogNameDescriptions = patchMemberConstraints.descriptionsForProperty("dogName");
+        List<String> addressDescriptions = patchMemberConstraints.descriptionsForProperty("address");
+        List<String> aboutMeDescriptions = patchMemberConstraints.descriptionsForProperty("aboutMe");
+
+        // When
+        ResultActions actions =
+                mockMvc.perform(
+                        multipart(MEMBER_DEFAULT_URL + "/" +
+                                MockTestData.MockMember.getMember().getMemberId())
+                                .file(patchDto)
+                                .file(profileImage)
+                                //.with(csrf())
+                                .contentType(MediaType.MULTIPART_FORM_DATA)
+                );
+
+        // Then
+        actions
+                .andExpect(status().isOk())
+                .andDo(document("Patch-Member",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+//                        pathParameters(
+//                                parameterWithName("member-id").description("회원 식별자")
+//                        ),
+                        requestPartBody(
+                                "patchDto"
+                        ),
+                        requestPartFields("patchDto",
+                                List.of(
+                                        fieldWithPath("nickname")
+                                                .type(JsonFieldType.STRING)
+                                                .description("견주 닉네임")
+                                                .attributes(key("constraints").value(nicknameDescriptions)),
+                                        fieldWithPath("dogName")
+                                                .type(JsonFieldType.STRING)
+                                                .description("강아지 이름")
+                                                .attributes(key("constraints").value(dogNameDescriptions)),
+                                        fieldWithPath("address")
+                                                .type(JsonFieldType.STRING)
+                                                .description("주소")
+                                                .attributes(key("constraints").value(addressDescriptions)),
+                                        fieldWithPath("aboutMe")
+                                                .type(JsonFieldType.STRING)
+                                                .description("강아지 소개")
+                                                .attributes(key("constraints").value(aboutMeDescriptions))
+                                )),
+                        relaxedRequestParts(
+                                partWithName("profileImage").description("첨부 파일")
+                        )));
+    }*/
+
+    @DisplayName("회원 상세 조회")
+    @Test
+    public void getMemberTest() throws Exception {
+        // Given
+        MemberResponseDto responseDto = MockTestData.MockMember.getMemberResponseDto();
+
+        given(memberService.getMember(Mockito.anyLong()))
+                .willReturn(new Member());
+        given(mapper.memberToMemberResponseDto(Mockito.any(Member.class)))
+                .willReturn(responseDto);
+
+        // When
+        ResultActions actions =
+                mockMvc.perform(
+                        get(MEMBER_DEFAULT_URL + "/{member-id}",
+                                MockTestData.MockMember.getMember().getMemberId())
+                                //.with(csrf())
+                                .accept(MediaType.APPLICATION_JSON)
+                );
+
+        // Then
+        actions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.nickname")
+                        .value(responseDto.getNickname()))
+                .andExpect(jsonPath("$.data.dogName")
+                        .value(responseDto.getDogName()))
+                .andExpect(jsonPath("$.data.dogGender")
+                        .value(responseDto.getDogGender().toString()))
+                .andExpect(jsonPath("$.data.aboutMe")
+                        .value(responseDto.getAboutMe()))
+                .andExpect(jsonPath("$.data.followerNumber")
+                        .value(responseDto.getFollowerNumber()))
+                .andExpect(jsonPath("$.data.followeeNumber")
+                        .value(responseDto.getFolloweeNumber()))
+                .andExpect(jsonPath("$.data.profileUrl")
+                        .value(responseDto.getProfileUrl()))
+                .andExpect(jsonPath("$.data.myBulletinPostDtos[0].bulletinPostId")
+                        .value(responseDto.getMyBulletinPostDtos().get(0).getBulletinPostId()))
+                .andExpect(jsonPath("$.data.myBulletinPostDtos[1].bulletinPostId")
+                        .value(responseDto.getMyBulletinPostDtos().get(1).getBulletinPostId()))
+                .andExpect(jsonPath("$.data.myAmenityDtos[0].amenityId")
+                        .value(responseDto.getMyAmenityDtos().get(0).getAmenityId()))
+                .andExpect(jsonPath("$.data.myAmenityDtos[1].amenityId")
+                        .value(responseDto.getMyAmenityDtos().get(1).getAmenityId()))
+                .andDo(document("Get-Member",
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                List.of(parameterWithName("member-id").description("회원 식별자"))
+                        ),
+                        responseFields(
+                                List.of(
+                                        fieldWithPath("code")
+                                                .type(JsonFieldType.STRING)
+                                                .description("HTTP Status"),
+                                        fieldWithPath("message")
+                                                .type(JsonFieldType.STRING)
+                                                .description("메시지"),
+                                        fieldWithPath("data")
+                                                .type(JsonFieldType.OBJECT)
+                                                .description("회원 정보"),
+                                        fieldWithPath("data.nickname")
+                                                .type(JsonFieldType.STRING)
+                                                .description("견주 닉네임"),
+                                        fieldWithPath("data.dogName")
+                                                .type(JsonFieldType.STRING)
+                                                .description("강아지 이름"),
+                                        fieldWithPath("data.dogGender")
+                                                .type(JsonFieldType.STRING)
+                                                .description("강아지 성별"),
+                                        fieldWithPath("data.aboutMe")
+                                                .type(JsonFieldType.STRING)
+                                                .description("강아지 소개"),
+                                        fieldWithPath("data.followerNumber")
+                                                .type(JsonFieldType.NULL)
+                                                .description("팔로워 수"),
+                                        fieldWithPath("data.followeeNumber")
+                                                .type(JsonFieldType.NULL)
+                                                .description("팔로잉 수"),
+                                        fieldWithPath("data.profileUrl")
+                                                .type(JsonFieldType.STRING)
+                                                .description("Profile URL 주소"),
+                                        fieldWithPath("data.myBulletinPostDtos[].bulletinPostId")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("게시물 식별자"),
+                                        fieldWithPath("data.myBulletinPostDtos[].photoUrl")
+                                                .type(JsonFieldType.STRING)
+                                                .description("게시물 사진 URL"),
+                                        fieldWithPath("data.myAmenityDtos[].amenityId")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("편의시설 식별자"),
+                                        fieldWithPath("data.myAmenityDtos[].amenityName")
+                                                .type(JsonFieldType.STRING)
+                                                .description("편의시설 이름"),
+                                        fieldWithPath("data.myAmenityDtos[].address")
+                                                .type(JsonFieldType.STRING)
+                                                .description("편의시설 주소"),
+                                        fieldWithPath("data.myAmenityDtos[].photoUrl")
+                                                .type(JsonFieldType.STRING)
+                                                .description("편의시설 사진 URL")
+                                )
+                        )
+                ));
+    }
+
+    @DisplayName("회원 리스트 조회 (운영자용)")
+    @Test
+    public void getMembersTest() throws Exception {
+        // Given
+        List<MemberListResponseDto> listResponseDtos = MockTestData.MockMember.getMemberListResponseDtos();
+
+        given(memberService.getMemberList(Mockito.anyInt(), Mockito.anyInt()))
+                .willReturn(MockTestData.MockMember.getPageMembers());
+        given(mapper.membersToMemberListResponseDtos(Mockito.anyList()))
+                .willReturn(listResponseDtos);
+
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.add("page", "1");
+        queryParams.add("size", "10");
+
+        // When
+        ResultActions actions =
+                mockMvc.perform(
+                        get(MEMBER_DEFAULT_URL)
+                                .params(queryParams)
+                                //.with(csrf())
+                                .accept(MediaType.APPLICATION_JSON)
+                );
+
+        // Then
+        actions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.*").exists())
+                .andExpect(jsonPath("$.data.*", hasSize(2)))
+                .andExpect(jsonPath("$.data[0].nickname")
+                        .value(listResponseDtos.get(0).getNickname()))
+                .andExpect(jsonPath("$.data[1].nickname")
+                        .value(listResponseDtos.get(1).getNickname()))
+                .andExpect(jsonPath("$.data[0].dogName")
+                        .value(listResponseDtos.get(0).getDogName()))
+                .andExpect(jsonPath("$.data[1].dogName")
+                        .value(listResponseDtos.get(1).getDogName()))
+                .andExpect(jsonPath("$.data[0].followerNumber")
+                        .value(listResponseDtos.get(0).getFollowerNumber()))
+                .andExpect(jsonPath("$.data[1].followerNumber")
+                        .value(listResponseDtos.get(1).getFollowerNumber()))
+                .andExpect(jsonPath("$.data[0].followeeNumber")
+                        .value(listResponseDtos.get(0).getFolloweeNumber()))
+                .andExpect(jsonPath("$.data[1].followeeNumber")
+                        .value(listResponseDtos.get(1).getFolloweeNumber()))
+                .andExpect(jsonPath("$.data[0].profileUrl")
+                        .value(listResponseDtos.get(0).getProfileUrl()))
+                .andExpect(jsonPath("$.data[1].profileUrl")
+                        .value(listResponseDtos.get(1).getProfileUrl()))
+                .andDo(document("Get-Members-for-Admin",
+                        preprocessResponse(prettyPrint()),
+                        requestParameters(
+                                List.of(
+                                        parameterWithName("page").description("페이지 번호"),
+                                        parameterWithName("size").description("페이지 당 회원 수")
+                                        //parameterWithName("_csrf").ignored()
+                                )
+                        ),
+                        responseFields(
+                                List.of(
+                                        fieldWithPath("code")
+                                                .type(JsonFieldType.STRING)
+                                                .description("HTTP Status"),
+                                        fieldWithPath("message")
+                                                .type(JsonFieldType.STRING)
+                                                .description("메시지"),
+                                        fieldWithPath("data[]")
+                                                .type(JsonFieldType.ARRAY)
+                                                .description("회원 리스트"),
+                                        fieldWithPath("data[].nickname")
+                                                .type(JsonFieldType.STRING)
+                                                .description("견주 닉네임"),
+                                        fieldWithPath("data[].dogName")
+                                                .type(JsonFieldType.STRING)
+                                                .description("강아지 이름"),
+                                        fieldWithPath("data[].followerNumber")
+                                                .type(JsonFieldType.NULL)
+                                                .description("팔로워 수"),
+                                        fieldWithPath("data[].followeeNumber")
+                                                .type(JsonFieldType.NULL)
+                                                .description("팔로잉 수"),
+                                        fieldWithPath("data[].profileUrl")
+                                                .type(JsonFieldType.STRING)
+                                                .description("Profile URL 주소"),
+                                        fieldWithPath("pageInfo.page")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("현재 페이지"),
+                                        fieldWithPath("pageInfo.size")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("페이지 당 회원 수"),
+                                        fieldWithPath("pageInfo.totalElements")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("총 회원 수"),
+                                        fieldWithPath("pageInfo.totalPages")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("총 페이지 수")
+                                )
+                        )
+                ));
+    }
+
+    @DisplayName("회원 삭제")
+    @Test
+    public void deleteMemberTest() throws Exception {
+        // Given
+        Member member = MockTestData.MockMember.getMember();
+
+        doNothing().when(memberService).deleteMember(member.getMemberId());
+
+        // When
+        ResultActions actions =
+                mockMvc.perform(
+                        delete(MEMBER_DEFAULT_URL + "/{member-id}", member.getMemberId())
+                                //.with(csrf())
+                                .accept(MediaType.APPLICATION_JSON)
+                );
+
+        // Then
+        actions
+                .andExpect(status().isNoContent())
+                .andExpect(jsonPath("$.data").doesNotExist())
+                .andDo(document("Delete-Member",
+                        pathParameters(
+                                parameterWithName("member-id").description("회원 식별자")
+                        )
+                ));
+    }
+}

--- a/backend/src/test/java/com/mybuddy/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/mybuddy/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,68 @@
+package com.mybuddy.member.repository;
+
+import com.mybuddy.global.config.TestConfig;
+import com.mybuddy.global.exception.LogicException;
+import com.mybuddy.global.exception.LogicExceptionCode;
+import com.mybuddy.global.mockdata.MockTestData;
+import com.mybuddy.member.entity.Member;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Import(TestConfig.class)
+public class MemberRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    Member member = MockTestData.MockMember.getMember();
+
+    @BeforeAll
+    public void init() {
+        memberRepository.save(member);
+    }
+
+    @Test
+    public void findByEmailTest() {
+        Optional<Member> optionalMember = memberRepository.findByEmail(member.getEmail());
+        Member obtainedMember = optionalMember.orElseThrow(() ->
+                new LogicException(LogicExceptionCode.MEMBER_NOT_FOUND));
+
+        assertEquals(obtainedMember.getMemberId(), member.getMemberId());
+        assertEquals(obtainedMember.getEmail(), member.getEmail());
+        assertEquals(obtainedMember.getPassword(), member.getPassword());
+        assertEquals(obtainedMember.getNickname(), member.getNickname());
+        assertEquals(obtainedMember.getAboutMe(), member.getAboutMe());
+        assertEquals(obtainedMember.getDogName(), member.getDogName());
+        assertEquals(obtainedMember.getDogGender(), member.getDogGender());
+        assertEquals(obtainedMember.getProfileUrl(), member.getProfileUrl());
+        assertEquals(obtainedMember.getAddress(), member.getAddress());
+    }
+
+    @Test
+    public void findByMemberIdAndMemberStatusIsTest() {
+        Optional<Member> optionalMember = memberRepository
+                .findByMemberIdAndMemberStatusIs(member.getMemberId(), Member.MemberStatus.ACTIVE);
+        Member obtainedMember = optionalMember.orElseThrow(() ->
+                new LogicException(LogicExceptionCode.MEMBER_NOT_FOUND));
+
+        assertEquals(obtainedMember.getMemberId(), member.getMemberId());
+        assertEquals(obtainedMember.getEmail(), member.getEmail());
+        assertEquals(obtainedMember.getPassword(), member.getPassword());
+        assertEquals(obtainedMember.getNickname(), member.getNickname());
+        assertEquals(obtainedMember.getAboutMe(), member.getAboutMe());
+        assertEquals(obtainedMember.getDogName(), member.getDogName());
+        assertEquals(obtainedMember.getDogGender(), member.getDogGender());
+        assertEquals(obtainedMember.getProfileUrl(), member.getProfileUrl());
+        assertEquals(obtainedMember.getAddress(), member.getAddress());
+    }
+}

--- a/backend/src/test/java/com/mybuddy/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/mybuddy/member/service/MemberServiceTest.java
@@ -1,0 +1,171 @@
+package com.mybuddy.member.service;
+
+import com.mybuddy.global.exception.LogicException;
+import com.mybuddy.global.mockdata.MockTestData;
+import com.mybuddy.global.storage.StorageService;
+import com.mybuddy.member.entity.Member;
+import com.mybuddy.member.entity.Member.MemberStatus;
+import com.mybuddy.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private StorageService storageService;
+
+    @Spy
+    @InjectMocks
+    private MemberServiceImpl memberService;
+
+    @DisplayName("회원 등록 로직 (Service)")
+    @Test
+    public void createMemberTest() {
+        // Given
+        Member member = MockTestData.MockMember.getMember();
+        MockMultipartFile profileImage = new MockMultipartFile("profileImage", "image.png",
+                MediaType.IMAGE_PNG_VALUE, "image".getBytes(StandardCharsets.UTF_8));
+
+        doNothing().when(memberService).verifyIfEmailExists(Mockito.anyString());
+        doNothing().when(storageService).storeImage(profileImage);
+        given(memberRepository.save(Mockito.any(Member.class)))
+                .willReturn(member);
+
+        // When
+        Executable executable = () -> memberService.createMember(member, profileImage);
+
+        // Then
+        assertDoesNotThrow(executable);
+    }
+
+    @DisplayName("회원 정보 수정 로직 (Service)")
+    @Test
+    public void updateMemberTest() {
+        // Given
+        Member member = MockTestData.MockMember.getMember();
+        MockMultipartFile profileImage = new MockMultipartFile("profileImage", "image.png",
+                MediaType.IMAGE_PNG_VALUE, "image".getBytes(StandardCharsets.UTF_8));
+
+        given(memberRepository.findByMemberIdAndMemberStatusIs(
+                Mockito.anyLong(), Mockito.any(MemberStatus.class)))
+                .willReturn(Optional.of(new Member()));
+        doNothing().when(storageService).storeImage(profileImage);
+        given(memberRepository.save(Mockito.any(Member.class)))
+                .willReturn(member);
+
+        // When
+        Executable executable = () -> memberService.updateMember(member, profileImage);
+
+        // Then
+        assertDoesNotThrow(executable);
+    }
+
+    @DisplayName("회원 상세 조회 로직 (Service)")
+    @Test
+    public void getMemberTest() {
+        // Given
+        Member obtainedMember = MockTestData.MockMember.getMember();
+
+        given(memberRepository.findByMemberIdAndMemberStatusIs(
+                Mockito.anyLong(), Mockito.any(MemberStatus.class)))
+                .willReturn(Optional.of(new Member()));
+
+        // When
+        Executable executable = () -> memberService.getMember(obtainedMember.getMemberId());
+
+        // Then
+        assertDoesNotThrow(executable);
+    }
+
+    @DisplayName("회원 리스트 조회 로직 (Service)")
+    @Test
+    public void getMemberListTest() {
+        // Given
+        Page<Member> pagedMembers = MockTestData.MockMember.getPageMembers();
+        int page = 1;
+        int size = 10;
+
+        given(memberRepository.findAll(PageRequest.of(page, size,
+                Sort.by("memberId").descending())))
+                .willReturn(pagedMembers);
+
+        // When
+        Executable executable = () -> memberService.getMemberList(page, size);
+
+        // Then
+        assertDoesNotThrow(executable);
+    }
+
+    @DisplayName("회원 삭제 로직 (Service)")
+    @Test
+    public void deleteMemberTest() {
+        // Given
+        Member obtainedMember = MockTestData.MockMember.getMember();
+
+        given(memberRepository.findByMemberIdAndMemberStatusIs(
+                Mockito.anyLong(), Mockito.any(MemberStatus.class)))
+                .willReturn(Optional.of(new Member()));
+        given(memberRepository.save(Mockito.any(Member.class)))
+                .willReturn(obtainedMember);
+
+        // When
+        Executable executable = () -> memberService.deleteMember(obtainedMember.getMemberId());
+
+        // Then
+        assertDoesNotThrow(executable);
+    }
+
+    @DisplayName("회원 이메일 존재 예외 처리 로직 (Service)")
+    @Test
+    public void verifyIfEmailExistsExceptionTest() {
+        // Given
+        Member obtainedMember = MockTestData.MockMember.getMember();
+
+        given(memberRepository.findByEmail(Mockito.anyString()))
+                .willReturn(Optional.of(obtainedMember));
+
+        // When
+        Executable executable = () -> memberService.verifyIfEmailExists(obtainedMember.getEmail());
+
+        // Then
+        assertThrows(LogicException.class, executable);
+    }
+
+    @DisplayName("회원 찾기 예외 처리 로직 (Service)")
+    @Test
+    public void findExistMemberByIdExceptionTest() {
+        // Given
+        given(memberRepository.findByMemberIdAndMemberStatusIs(
+                Mockito.anyLong(), Mockito.any(MemberStatus.class)))
+                .willReturn(Optional.empty());
+
+        // When
+        Executable executable = () -> memberService.findExistMemberById(1L);
+
+        // Then
+        assertThrows(LogicException.class, executable);
+    }
+}

--- a/backend/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/backend/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,12 @@
+|===
+|필드명|타입|필수값 여부|설명|제약 조건
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#constraints}}{{.}} {{/constraints}}{{/tableCellContent}}
+{{/fields}}
+
+|===

--- a/backend/src/test/resources/org/springframework/restdocs/templates/request-parameters.snippet
+++ b/backend/src/test/resources/org/springframework/restdocs/templates/request-parameters.snippet
@@ -1,0 +1,11 @@
+|===
+|파라미터명|필수값 여부|설명
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/parameters}}
+
+|===

--- a/backend/src/test/resources/org/springframework/restdocs/templates/request-part-fields.snippet
+++ b/backend/src/test/resources/org/springframework/restdocs/templates/request-part-fields.snippet
@@ -1,0 +1,12 @@
+|===
+|필드명|타입|필수값 여부|설명|제약 조건
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#constraints}}{{.}} {{/constraints}}{{/tableCellContent}}
+{{/fields}}
+
+|===


### PR DESCRIPTION
이번 PR에서 가장 중요한 작업은 Member 관련 테스트 추가입니다.

현재 MultipartFile과 관련된 테스트는 post 밖에 되지 않으므로 patchMemberTest()는 주석 처리 되어있습니다. 추후 방법이 결정되면 주석을 풀고 알맞게 수정이 될 예정입니다.

제가 바로 머지하지 않고 있을테니 리뷰어들께서 한 번 살펴보셨으면 합니다.

나머지는 아래의 commit 목록을 참고 바랍니다.