### PR TITLE
[추가] 특정 장소와 태그된 게시글들 페이지네이션 처리해 반환

### DIFF
--- a/backend/src/main/java/com/mybuddy/amenity/controller/AmenityController.java
+++ b/backend/src/main/java/com/mybuddy/amenity/controller/AmenityController.java
@@ -2,14 +2,12 @@ package com.mybuddy.amenity.controller;
 
 import com.mybuddy.amenity.dto.AmenityCreateDto;
 import com.mybuddy.amenity.dto.AmenityResponseDto;
+import com.mybuddy.amenity.dto.AmenityWithBulletinPost;
 import com.mybuddy.amenity.entity.Amenity;
 import com.mybuddy.amenity.mapper.AmenityMapper;
 import com.mybuddy.amenity.service.AmenityService;
-import com.mybuddy.bulletin_post.entity.BulletinPost;
-import com.mybuddy.global.utils.ApiMultiResponse;
 import com.mybuddy.global.utils.ApiSingleResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -42,16 +40,14 @@ public class AmenityController {
 
 
     @GetMapping("{amenity-id}")
-    public void getAmenityWithBulletinPost(@PathVariable("amenity-id") Long amenityId,
-                                           @RequestParam(name = "page") String page,
-                                            @RequestParam(name = "size") String size) {
+    public ResponseEntity<ApiSingleResponse> findAmenityWithBulletinPostByAmenityId(@PathVariable("amenity-id") Long amenityId,
+                                                                        @RequestParam(name = "page") int page,
+                                                                        @RequestParam(name = "size") int size) {
 
-//        Page<BulletinPost> pageBulletinPosts = bulletinPostService.findAmenityBulletinPosts(page - 1, size);
-//        List<BulletinPost> bulletinPosts = pageBulletinPosts.getContent();
-//        return new ResponseEntity<>(
-//                new ApiMultiResponse<>(HttpStatus.OK, "message", bulletinPostMapper.bulletinPostsToBulletinPostResponseForFeedDtos(bulletinPosts),
-//                        pageBulletinPosts),
-//                HttpStatus.OK);
+        AmenityWithBulletinPost amenityWithBulletinPost = amenityService.getAmenityWithBulletinPost(amenityId, page - 1, size);
+
+        ApiSingleResponse response = new ApiSingleResponse<>(HttpStatus.OK,"장소와 그 장소가 태그된 게시물들 반환", amenityWithBulletinPost);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping

--- a/backend/src/main/java/com/mybuddy/amenity/dto/AmenityWithBulletinPost.java
+++ b/backend/src/main/java/com/mybuddy/amenity/dto/AmenityWithBulletinPost.java
@@ -1,8 +1,11 @@
 package com.mybuddy.amenity.dto;
 
 import com.mybuddy.bulletin_post.dto.BulletinPostDto;
-import com.mybuddy.bulletin_post.entity.BulletinPost;
+import com.mybuddy.global.utils.PageInfo;
+import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 
 import java.util.List;
 
@@ -15,7 +18,21 @@ public class AmenityWithBulletinPost {
     private Double longitude;
     private Double latitude;
 
-    // 태그된 bulletinPost응답 dto 담기
-    // public List<BulletinPostDto>;
+     private List<BulletinPostDto.ResponseForFeed> bulletinPosts;
 
+    private PageInfo pageInfo;
+    //AmenityCustomRepository에서 처리하려면 여기에 PageInfo가 필요해져서 추가 됨
+    //다음 수정 시 ApiMultiResponse를 이용해 처리할 예정(2023.03.12 강지은)
+
+     @Builder
+    public AmenityWithBulletinPost(Long addressId, String amenityName, String address, Double longitude, Double latitude, List<BulletinPostDto.ResponseForFeed> bulletinPosts, Page page) {
+        this.addressId = addressId;
+        this.amenityName = amenityName;
+        this.address = address;
+        this.longitude = longitude;
+        this.latitude = latitude;
+        this.bulletinPosts = bulletinPosts;
+        this.pageInfo = new PageInfo(page.getNumber() + 1,
+                 page.getSize(), page.getTotalElements(), page.getTotalPages());
+    }
 }

--- a/backend/src/main/java/com/mybuddy/amenity/mapper/AmenityMapper.java
+++ b/backend/src/main/java/com/mybuddy/amenity/mapper/AmenityMapper.java
@@ -12,12 +12,12 @@ import java.util.List;
 public interface AmenityMapper {
 
 
-    Amenity AmenityCreateDtoToAmenity(AmenityCreateDto amenityCreateDto);
-    AmenityResponseDto AmenityToAmenityResponseDto(Amenity amenity);
+    Amenity amenityCreateDtoToAmenity(AmenityCreateDto amenityCreateDto);
+    AmenityResponseDto amenityToAmenityResponseDto(Amenity amenity);
 
     List<AmenityResponseDto> AmenityListToAmenityResponseDto(List<Amenity> amenityList);
 
-    default AmenityCreateDto BullletinPostCreateDtoToAmenityCreateDto(BulletinPostDto.Create bulletinPostCreateDto) {
+    default AmenityCreateDto bullletinPostCreateDtoToAmenityCreateDto(BulletinPostDto.Create bulletinPostCreateDto) {
         if ( bulletinPostCreateDto == null ) {
             return null;
         }

--- a/backend/src/main/java/com/mybuddy/amenity/repository/AmenityCustomRepository.java
+++ b/backend/src/main/java/com/mybuddy/amenity/repository/AmenityCustomRepository.java
@@ -1,7 +1,9 @@
 package com.mybuddy.amenity.repository;
 
 import com.mybuddy.amenity.dto.AmenityResponseDto;
+import com.mybuddy.amenity.dto.AmenityWithBulletinPost;
 import com.mybuddy.amenity.entity.Amenity;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
@@ -9,7 +11,7 @@ public interface AmenityCustomRepository {
 
     Amenity findByAddressId(Long addressId);
 
-    List<Amenity> findByBulletinPostId(Long bulletinPostId);
+    AmenityWithBulletinPost findAmenityWithBulletinPostByAmenityId(Long amenityId, PageRequest pageRequest);
 
     List<AmenityResponseDto> findByStateRegion(String state, String region);
 }

--- a/backend/src/main/java/com/mybuddy/amenity/service/AmenityService.java
+++ b/backend/src/main/java/com/mybuddy/amenity/service/AmenityService.java
@@ -39,7 +39,7 @@ public class AmenityService {
 
     @Transactional
     public Amenity createAmenity(AmenityCreateDto amenityCreateDto) {
-        Amenity amenity = amenityMapper.AmenityCreateDtoToAmenity(amenityCreateDto);
+        Amenity amenity = amenityMapper.amenityCreateDtoToAmenity(amenityCreateDto);
         return amenityRepository.save(amenity);
     }
 

--- a/backend/src/main/java/com/mybuddy/amenity/service/AmenityService.java
+++ b/backend/src/main/java/com/mybuddy/amenity/service/AmenityService.java
@@ -2,10 +2,13 @@ package com.mybuddy.amenity.service;
 
 import com.mybuddy.amenity.dto.AmenityCreateDto;
 import com.mybuddy.amenity.dto.AmenityResponseDto;
+import com.mybuddy.amenity.dto.AmenityWithBulletinPost;
 import com.mybuddy.amenity.entity.Amenity;
 import com.mybuddy.amenity.mapper.AmenityMapper;
 import com.mybuddy.amenity.repository.AmenityRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -44,10 +47,10 @@ public class AmenityService {
     }
 
     @Transactional
-    public void getAmenityWithBulletinPost(Long amenityId) {
+    public AmenityWithBulletinPost getAmenityWithBulletinPost(Long amenityId, int page, int size) {
 
-        //해당 amenity id 가 태그된 bulletin post들이 페이지 처리되어 반환..
-        //bulletinPostRepository.findByAmenityId(amenityId);
+        return amenityRepository.findAmenityWithBulletinPostByAmenityId(amenityId,
+                PageRequest.of(page, size, Sort.by("bulletinPostId").descending()));
     }
 
     @Transactional

--- a/backend/src/main/java/com/mybuddy/bulletin_post/controller/BulletinPostController.java
+++ b/backend/src/main/java/com/mybuddy/bulletin_post/controller/BulletinPostController.java
@@ -48,7 +48,7 @@ public class BulletinPostController {
 //        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 //        UserDetails userDetails = (UserDetails)principal;
 //        long memberId = principal.getMemberId();
-        AmenityCreateDto amenityCreateDto = amenityMapper.BullletinPostCreateDtoToAmenityCreateDto(bulletinPostCreateDto);
+        AmenityCreateDto amenityCreateDto = amenityMapper.bullletinPostCreateDtoToAmenityCreateDto(bulletinPostCreateDto);
         Amenity amenity = amenityService.findDBAmenity(amenityCreateDto);
 
 //        image 저장시 밑의 걸로 바꿔줘야함

--- a/backend/src/main/java/com/mybuddy/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/mybuddy/comment/controller/CommentController.java
@@ -33,9 +33,9 @@ public class CommentController {
 
         Long bulletinPostId = commentCreateDto.getBulletinPostId();
 
-        Comment comment = commentService.createComment(bulletinPostId ,commentMapper.CommentCreateDtoToComment(commentCreateDto));
+        Comment comment = commentService.createComment(bulletinPostId ,commentMapper.commentCreateDtoToComment(commentCreateDto));
         URI uri = UriMaker.getUri(defaultUrl, comment.getCommentId());
-        CommentResponseDto commentResponseDto = commentMapper.CommentToCommentResponseDto(comment);
+        CommentResponseDto commentResponseDto = commentMapper.commentToCommentResponseDto(comment);
         ApiSingleResponse response = new ApiSingleResponse(HttpStatus.CREATED,"댓글이 생성되었습니다", commentResponseDto);
         return ResponseEntity.created(uri).body(response);
     }
@@ -45,7 +45,7 @@ public class CommentController {
     public ResponseEntity<ApiSingleResponse> getComments(@RequestParam(name = "bulletinPostId") @Positive Long postId) {
         //bulletinPost 엔티티 생성후 제작
         List<Comment> commentList = commentService.getCommentsByBulletinPostId(postId);
-        List<CommentResponseDto> commentResponseDtos = commentMapper.CommentListToCommentResponseDtoList(commentList);
+        List<CommentResponseDto> commentResponseDtos = commentMapper.commentListToCommentResponseDtoList(commentList);
 
         ApiSingleResponse response = new ApiSingleResponse(HttpStatus.OK,"게시물에 해당하는 댓글 정보입니다.", commentResponseDtos);
 
@@ -57,8 +57,8 @@ public class CommentController {
                                                            @Valid @RequestBody CommentUpdateDto commentUpdateDto) {
 
         commentUpdateDto.setCommentId(commentId);
-        Comment updatedComment = commentService.updateComment(commentMapper.CommentUpdateDtoToComment(commentUpdateDto));
-        CommentResponseDto commentResponseDto = commentMapper.CommentToCommentResponseDto(updatedComment);
+        Comment updatedComment = commentService.updateComment(commentMapper.commentUpdateDtoToComment(commentUpdateDto));
+        CommentResponseDto commentResponseDto = commentMapper.commentToCommentResponseDto(updatedComment);
 
         ApiSingleResponse response = new ApiSingleResponse(HttpStatus.OK,"댓글이 수정되었습니다", commentResponseDto);
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/com/mybuddy/comment/mapper/CommentMapper.java
+++ b/backend/src/main/java/com/mybuddy/comment/mapper/CommentMapper.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface CommentMapper {
-    default Comment CommentCreateDtoToComment(CommentCreateDto commentCreateDto){
+    default Comment commentCreateDtoToComment(CommentCreateDto commentCreateDto){
         if ( commentCreateDto == null )
             return null;
 
@@ -19,7 +19,7 @@ public interface CommentMapper {
                 .commentContent(commentCreateDto.getCommentContent())
                 .build();
     }
-    default Comment CommentUpdateDtoToComment(CommentUpdateDto commentUpdateDto) {
+    default Comment commentUpdateDtoToComment(CommentUpdateDto commentUpdateDto) {
 
         if ( commentUpdateDto == null )
             return null;
@@ -32,7 +32,7 @@ public interface CommentMapper {
 
     }
 
-    default CommentResponseDto CommentToCommentResponseDto(Comment comment) {
+    default CommentResponseDto commentToCommentResponseDto(Comment comment) {
         if ( comment == null ) {
             return null;
         }
@@ -48,6 +48,6 @@ public interface CommentMapper {
         return commentResponseDto;
     }
 
-    List<CommentResponseDto> CommentListToCommentResponseDtoList(List<Comment> commentList);
+    List<CommentResponseDto> commentListToCommentResponseDtoList(List<Comment> commentList);
 }
 


### PR DESCRIPTION
✅ 일단 작동하는 코드를 추가해놓았습니다. 효율성에 의해 설계를 약간 변경후 리팩토링할 예정입니다.

- BulletinPost가 페이징처리되어 지속적으로 요청이 오는데, 장소 정보를 계속 조회하면 효율성이 ⬇️ 👎
- Amenity 1개 조회,  AmenityId로 BulletinPostList를 조회하는 로직상 분리가 필요할 듯합니다.
- 나중에 bulletinPost custom repository 생성되면 수정이 필요합니다.

현재 반환하는 데이터는 다음과 같은 형태를 갖고 있는데 

Amenity와 BulletinPost를 분리하지 않을 경우  ApiMultiResponse를 바로 사용할 수 없어 
응답데이터를 약간 변경하게 되었는데요, 이 역시 설계가 변경되어야 함을 느낀 이유 중 하나입니다.

```json
{
    "code": "200",
    "message": "장소와 그 장소가 태그된 게시물들 반환",
    "data": {
        "addressId": 1472201342221,
        "amenityName": "장소1",
        "address": "서울 노원구 어딘가 주소입니다.",
        "longitude": 126.12834637823106,
        "latitude": 126.12834637823106,
        "bulletinPosts": [
            {
                "bulletinPostId": 1,
                "photoUrl": "/photoUrl/blah/blah/blah",
                "postContent": "게시물 1 !!"
            },
            {
                "bulletinPostId": 2,
                "photoUrl": "/photoUrl/blah/blah/blah",
                "postContent": "게시물 2 !!"
            },
            {
                "bulletinPostId": 3,
                "photoUrl": "/photoUrl/blah/blah/blah",
                "postContent": "게시물 3 !!"
            }
        ],
        "pageInfo": {
            "page": 1,
            "size": 3,
            "totalElements": 5,
            "totalPages": 2
        }
    }
}
```