### PR TITLE
[추가/수정] 닉네임 중복 여부 확인 메서드 추가/query 방법 변경 (2023.03.13 강지후)

### DIFF
--- a/backend/src/main/java/com/mybuddy/global/exception/LogicExceptionCode.java
+++ b/backend/src/main/java/com/mybuddy/global/exception/LogicExceptionCode.java
@@ -6,6 +6,7 @@ public enum LogicExceptionCode {
 
     MEMBER_NOT_FOUND(404, "Member not found"),
     MEMBER_ALREADY_EXISTS(409, "Member already exists"),
+    NICKNAME_ALREADY_EXISTS(409, "Nickname already exists"),
     BULLETIN_POST_NOT_FOUND(404, "Post not found"),
     COMMENT_NOT_FOUND(404, "Comment not found");
 

--- a/backend/src/main/java/com/mybuddy/member/repository/MemberCustomRepository.java
+++ b/backend/src/main/java/com/mybuddy/member/repository/MemberCustomRepository.java
@@ -1,0 +1,14 @@
+package com.mybuddy.member.repository;
+
+import com.mybuddy.member.entity.Member;
+
+import java.util.Optional;
+
+public interface MemberCustomRepository {
+
+    Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByNickname(String nickname);
+
+    Optional<Member> findByMemberIdAndMemberStatusIs(Long memberId, Member.MemberStatus memberStatus);
+}

--- a/backend/src/main/java/com/mybuddy/member/repository/MemberCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/mybuddy/member/repository/MemberCustomRepositoryImpl.java
@@ -1,0 +1,54 @@
+package com.mybuddy.member.repository;
+
+import com.mybuddy.member.entity.Member;
+import com.mybuddy.member.entity.QMember;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class MemberCustomRepositoryImpl implements MemberCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Member> findByEmail(String email) {
+        QMember member = new QMember("member1");
+
+        return Optional.ofNullable(
+                queryFactory
+                        .select(member)
+                        .from(member)
+                        .where(member.email.eq(email))
+                        .fetchOne()
+        );
+    }
+
+    @Override
+    public Optional<Member> findByNickname(String nickname) {
+        QMember member = new QMember("member1");
+
+        return Optional.ofNullable(
+                queryFactory
+                        .select(member)
+                        .from(member)
+                        .where(member.nickname.eq(nickname))
+                        .fetchOne()
+        );
+    }
+
+    @Override
+    public Optional<Member> findByMemberIdAndMemberStatusIs(Long memberId, Member.MemberStatus memberStatus) {
+        QMember member = new QMember("member1");
+
+        return Optional.ofNullable(
+                queryFactory
+                        .select(member)
+                        .from(member)
+                        .where(member.memberId.eq(memberId)
+                                .and(member.memberStatus.eq(memberStatus)))
+                        .fetchOne()
+        );
+    }
+}

--- a/backend/src/main/java/com/mybuddy/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/mybuddy/member/repository/MemberRepository.java
@@ -2,16 +2,9 @@ package com.mybuddy.member.repository;
 
 
 import com.mybuddy.member.entity.Member;
-import com.mybuddy.member.entity.Member.MemberStatus;
 
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
 
-    Optional<Member> findByEmail(String email);
-
-    Optional<Member> findByNickname(String nickname);
-
-    Optional<Member> findByMemberIdAndMemberStatusIs(Long memberId, MemberStatus memberStatus);
 }

--- a/backend/src/main/java/com/mybuddy/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/mybuddy/member/repository/MemberRepository.java
@@ -11,5 +11,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
 
+    Optional<Member> findByNickname(String nickname);
+
     Optional<Member> findByMemberIdAndMemberStatusIs(Long memberId, MemberStatus memberStatus);
 }

--- a/backend/src/main/java/com/mybuddy/member/service/MemberService.java
+++ b/backend/src/main/java/com/mybuddy/member/service/MemberService.java
@@ -2,12 +2,8 @@ package com.mybuddy.member.service;
 
 import com.mybuddy.member.entity.Member;
 import org.springframework.data.domain.Page;
-import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-
-@Service
 public interface MemberService {
 
     Member createMember(Member member, MultipartFile profileImage);
@@ -21,6 +17,8 @@ public interface MemberService {
     void deleteMember(Long memberId);
 
     void verifyIfEmailExists(String email);
+
+    void verifyIfNicknameExists(String nickname);
 
     Member findExistMemberById(Long memberId);
 }

--- a/backend/src/main/java/com/mybuddy/member/service/MemberServiceImpl.java
+++ b/backend/src/main/java/com/mybuddy/member/service/MemberServiceImpl.java
@@ -35,6 +35,7 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public Member createMember(Member member, MultipartFile profileImage) {
         verifyIfEmailExists(member.getEmail());
+        verifyIfNicknameExists(member.getNickname());
 
         Optional.ofNullable(profileImage)
                 .ifPresent(storageService::storeImage);
@@ -100,6 +101,14 @@ public class MemberServiceImpl implements MemberService {
 
         if (optionalMember.isPresent())
             throw new LogicException(LogicExceptionCode.MEMBER_ALREADY_EXISTS);
+    }
+
+    @Override
+    public void verifyIfNicknameExists(String nickname) {
+        Optional<Member> optionalMember = memberRepository.findByNickname(nickname);
+
+        if (optionalMember.isPresent())
+            throw new LogicException(LogicExceptionCode.NICKNAME_ALREADY_EXISTS);
     }
 
     @Override

--- a/backend/src/test/java/com/mybuddy/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/mybuddy/member/repository/MemberRepositoryTest.java
@@ -49,6 +49,23 @@ public class MemberRepositoryTest {
     }
 
     @Test
+    public void findByNicknameTest() {
+        Optional<Member> optionalMember = memberRepository.findByNickname(member.getNickname());
+        Member obtainedMember = optionalMember.orElseThrow(() ->
+                new LogicException(LogicExceptionCode.MEMBER_NOT_FOUND));
+
+        assertEquals(obtainedMember.getMemberId(), member.getMemberId());
+        assertEquals(obtainedMember.getEmail(), member.getEmail());
+        assertEquals(obtainedMember.getPassword(), member.getPassword());
+        assertEquals(obtainedMember.getNickname(), member.getNickname());
+        assertEquals(obtainedMember.getAboutMe(), member.getAboutMe());
+        assertEquals(obtainedMember.getDogName(), member.getDogName());
+        assertEquals(obtainedMember.getDogGender(), member.getDogGender());
+        assertEquals(obtainedMember.getProfileUrl(), member.getProfileUrl());
+        assertEquals(obtainedMember.getAddress(), member.getAddress());
+    }
+
+    @Test
     public void findByMemberIdAndMemberStatusIsTest() {
         Optional<Member> optionalMember = memberRepository
                 .findByMemberIdAndMemberStatusIs(member.getMemberId(), Member.MemberStatus.ACTIVE);

--- a/backend/src/test/java/com/mybuddy/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/mybuddy/member/service/MemberServiceTest.java
@@ -154,6 +154,22 @@ public class MemberServiceTest {
         assertThrows(LogicException.class, executable);
     }
 
+    @DisplayName("회원 별명 존재 예외 처리 로직 (Service)")
+    @Test
+    public void verifyIfNicknameExistsExceptionTest() {
+        // Given
+        Member obtainedMember = MockTestData.MockMember.getMember();
+
+        given(memberRepository.findByNickname(Mockito.anyString()))
+                .willReturn(Optional.of(obtainedMember));
+
+        // When
+        Executable executable = () -> memberService.verifyIfNicknameExists(obtainedMember.getNickname());
+
+        // Then
+        assertThrows(LogicException.class, executable);
+    }
+
     @DisplayName("회원 찾기 예외 처리 로직 (Service)")
     @Test
     public void findExistMemberByIdExceptionTest() {


### PR DESCRIPTION
아래와 같이 update 되었습니다.

1. Member entity 자체의 유효성 검사를 사용하기 전 예외 처리를 위해 verifyIfNicknameExists()를 추가.
2. MemberRepository 대신 MemberCustomRepository로 query를 받도록 변경. (queryDsl 사용)