### PR TITLE
[수정] comment findByBulletinPostId 적용

### DIFF
--- a/backend/src/main/java/com/mybuddy/comment/repository/CommentCustomRepository.java
+++ b/backend/src/main/java/com/mybuddy/comment/repository/CommentCustomRepository.java
@@ -1,5 +1,9 @@
 package com.mybuddy.comment.repository;
 
+import com.mybuddy.comment.entity.Comment;
+
+import java.util.List;
+
 public interface CommentCustomRepository {
-    void findByBulletinPostId(Long bulletinPostId);
+    List<Comment> findByBulletinPostId(Long bulletinPostId);
 }

--- a/backend/src/main/java/com/mybuddy/comment/repository/CommentCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/mybuddy/comment/repository/CommentCustomRepositoryImpl.java
@@ -1,16 +1,27 @@
 package com.mybuddy.comment.repository;
 
+import com.mybuddy.bulletin_post.entity.QBulletinPost;
+import com.mybuddy.comment.entity.Comment;
 import com.mybuddy.comment.entity.QComment;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 public class CommentCustomRepositoryImpl implements CommentCustomRepository{
 
     private final JPAQueryFactory queryFactory;
     @Override
-    public void findByBulletinPostId(Long bulletinPostId) {
-        QComment c = new QComment("c");
-//        queryFactory.select(c)
+    public List<Comment> findByBulletinPostId(Long bulletinPostId) {
+        QComment comment = QComment.comment;
+        QBulletinPost bulletinPost = QBulletinPost.bulletinPost;
+
+        return queryFactory.select(comment)
+                .from(comment)
+                .join(comment.bulletinPost, bulletinPost)
+                .where(comment.bulletinPost.bulletinPostId.eq(bulletinPostId))
+                .orderBy(comment.commentId.desc())
+                .fetch();
     }
 }

--- a/backend/src/main/java/com/mybuddy/comment/service/CommentService.java
+++ b/backend/src/main/java/com/mybuddy/comment/service/CommentService.java
@@ -44,8 +44,7 @@ public class CommentService {
         //BulletinPost의 verfied 검증 로직 추가
         bulletinPostRepository.findById(bulletinPostId).orElseThrow(()-> new RuntimeException("CUSTOM EXCEPTION으로 변경 예정"));
 
-        List<Comment> comments = commentRepository.findAll();
-        //commentRepository.findByBulletinPostId(postId); 위는 정상적으로 작동하기 위한 findAll()이며, 이걸로 대체할 예정입니다.(2023.03.08 강지은)
+        List<Comment> comments = commentRepository.findByBulletinPostId(bulletinPostId);
 
         return comments;
     }


### PR DESCRIPTION
GET api/v1/bulletin-posts/1로 응답 json잘 돌아오는 것 확인했습니다.

```json
{
    "code": "200",
    "message": "게시물 1개 조회",
    "data": {
        "bulletinPostId": 1,
        "photoUrl": "/Users/kangjieun/IdeaProjects/seb42_main_011/USER - SIGN IN.png",
        "postContent": "게시물4 !!",
        "createdAt": "2023-03-15T16:13:11.12849",
        "memberId": 1,
        "nickname": "코딩김",
        "dogName": "왕밤톨",
        "profileUrl": null,
        "amenityId": 1,
        "amenityName": "장소2",
        "likeCount": 1,
        "likeByUser": 2,
        "commentList": [
            {
                "commentId": 2,
                "commentContent": "우와 콩이가 너무 귀여워요",
                "memberId": 1,
                "nickName": "코딩김",
                "dogName": "왕밤톨"
            },
            {
                "commentId": 3,
                "commentContent": "우와 콩이가 너무 귀여워요zzzzzz",
                "memberId": 1,
                "nickName": "코딩김",
                "dogName": "왕밤톨"
            },
            {
                "commentId": 4,
                "commentContent": "우와 콩이가 너무 귀여워요zzzzzzasdsads",
                "memberId": 1,
                "nickName": "코딩김",
                "dogName": "왕밤톨"
            },
            {
                "commentId": 8,
                "commentContent": "asdjgjewfaj",
                "memberId": 1,
                "nickName": "코딩김",
                "dogName": "왕밤톨"
            }
        ],
        "commentCount": 4
    }
}
```