### PR TITLE
[수정/기타] 게시글 상세보기에서 댓글 최신순 (desc) 반환, id전략 변경

### DIFF
--- a/backend/src/main/java/com/mybuddy/amenity/entity/Amenity.java
+++ b/backend/src/main/java/com/mybuddy/amenity/entity/Amenity.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class Amenity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long amenityId;
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/mybuddy/bulletin_post/mapper/BulletinPostMapper.java
+++ b/backend/src/main/java/com/mybuddy/bulletin_post/mapper/BulletinPostMapper.java
@@ -9,6 +9,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -51,7 +52,8 @@ public interface BulletinPostMapper {
                     );
                     return commentResponse;
                 }
-                ).collect(Collectors.toList());
+                ).sorted(Comparator.comparingLong(CommentResponseDto::getCommentId).reversed())
+                .collect(Collectors.toList());
 
         //like count, like chosen 추후수정
 //        likeCount = bulletinPostService.getLikeCount(bulletinPostId);

--- a/backend/src/main/java/com/mybuddy/comment/entity/Comment.java
+++ b/backend/src/main/java/com/mybuddy/comment/entity/Comment.java
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 public class Comment {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long commentId;
 
     @Column(length = 1000, nullable = false)


### PR DESCRIPTION
# 게시글 상세보기 댓글 최신순
FeedResponse에는 반영하지 않았습니다. 
FeedResponse에서는 댓글 정보를 안가져가고(null), 댓글의 개수만 반환하는게 좋을것 같습니다.  

# Id 전략 변경에 대하여
id전략 AUTO와 IDENTITY 전략이 크게 다를게 없지만, 
테스트상에서 id가 2번부터 생성되는 오류 해결 및 추후 RDS로 Mysql을 사용할 것을 생각해 Identity로 변경하였습니다.