### PR TITLE
[추가/수정] 회원 구분 및 중복 검사 API 추가 / RestDocs 수정 (2023.03.24 강지후)

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -40,7 +40,7 @@ include::{snippets}/update-member/request-headers.adoc[]
 include::{snippets}/get-member/path-parameters.adoc[]
 
 .request-fields
-include::{snippets}/update-member/request-part-patchDto-fields.adoc[]
+include::{snippets}/update-member/request-part-updateDto-fields.adoc[]
 
 .request-part
 include::{snippets}/update-member/request-parts.adoc[]

--- a/backend/src/main/java/com/mybuddy/member/controller/MemberController.java
+++ b/backend/src/main/java/com/mybuddy/member/controller/MemberController.java
@@ -87,4 +87,27 @@ public class MemberController {
 
         return ResponseEntity.noContent().build();
     }
+
+    @GetMapping("/{member-id}/info")
+    public ResponseEntity getMemberInfoForRecognition(@Min(2L) @PathVariable("member-id") Long memberId) {
+        // 단순히 회원 정보의 일부만 보내주면 되므로 ApiSingleResponseDto는 사용하지 않음.
+        return new ResponseEntity(
+                mapper.memberToMemberInfoResponseDto(memberService.getMember(memberId)), HttpStatus.OK);
+    }
+
+    @GetMapping("/check")
+    public ResponseEntity<ApiSingleResponse> getDuplicateCheckResult(@RequestParam(required = false) String email,
+                                                  @RequestParam(required = false) String nickname) {
+        // 이메일 및 닉네임 중복 체크 메서드
+        if (email != null) {
+            memberService.verifyIfEmailExists(email);
+        } else if (nickname != null) {
+            memberService.verifyIfNicknameExists(nickname);
+        }
+
+        ApiSingleResponse response =
+                new ApiSingleResponse(HttpStatus.OK, "사용 가능합니다.");
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/backend/src/main/java/com/mybuddy/member/dto/MemberInfoResponseDto.java
+++ b/backend/src/main/java/com/mybuddy/member/dto/MemberInfoResponseDto.java
@@ -1,0 +1,24 @@
+package com.mybuddy.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberInfoResponseDto {
+
+    private final Long memberId;
+
+    private final String nickname;
+
+    private final String dogName;
+
+    private final String profileUrl;
+
+    @Builder
+    public MemberInfoResponseDto(Long memberId, String nickname, String dogName, String profileUrl) {
+        this.memberId = memberId;
+        this.nickname = nickname;
+        this.dogName = dogName;
+        this.profileUrl = profileUrl;
+    }
+}

--- a/backend/src/main/java/com/mybuddy/member/mapper/MemberMapper.java
+++ b/backend/src/main/java/com/mybuddy/member/mapper/MemberMapper.java
@@ -110,4 +110,6 @@ public interface MemberMapper {
 
     @IterableMapping(qualifiedByName = "MTMLR")
     List<MemberListResponseDto> membersToMemberListResponseDtos(List<Member> members);
+
+    MemberInfoResponseDto memberToMemberInfoResponseDto(Member member);
 }


### PR DESCRIPTION
추가 내용은 아래와 같습니다.

1. 회원 구분을 위한 API ```/api/v1/members/{member-id}/info```
2. 이메일 혹은 닉네임으로 중복 검사하는 API ```/api/v1/members/check```