### PR TITLE
[수정] Refresh Token 전송 방법 쿠키로 변경 (2023.03.24 강지후)

### DIFF
--- a/backend/src/main/java/com/mybuddy/global/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/mybuddy/global/auth/controller/AuthController.java
@@ -32,13 +32,13 @@ public class AuthController {
 
     @PostMapping("/refresh")
     public ResponseEntity refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
-        String refreshToken = request.getHeader("Refresh");
+        // 헤더 적용 시에 사용
+        // String refreshToken = request.getHeader("Refresh");
 
-        // 쿠키 적용 시에 사용
-        /*String refreshToken = Arrays.stream(request.getCookies())
+        String refreshToken = Arrays.stream(request.getCookies())
                 .filter(cookie -> cookie.getName().equals("Refresh"))
                 .map(Cookie::getValue)
-                .collect(Collectors.joining(""));*/
+                .collect(Collectors.joining(""));
 
         String email = jwtTokenizer.getSubject(refreshToken);
 
@@ -50,13 +50,6 @@ public class AuthController {
         }
 
         String newAccessToken = jwtTokenizer.delegateAccessToken(obtainedMember);
-
-        // 쿠키 적용 시에 사용
-        /*Cookie cookie = new Cookie("Authorization", "Bearer " + newAccessToken);
-        cookie.setPath("/");
-        cookie.setHttpOnly(false);
-        cookie.setMaxAge(1200);
-        response.addCookie(cookie);*/
 
         response.addHeader("Authorization", "Bearer " + newAccessToken);
 

--- a/backend/src/main/java/com/mybuddy/global/auth/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/mybuddy/global/auth/filter/JwtAuthenticationFilter.java
@@ -14,6 +14,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -56,7 +57,15 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
                 TimeUnit.MINUTES);
 
         response.setHeader("Authorization", "Bearer " + accessToken);
-        response.setHeader("Refresh", refreshToken);
+        // 헤더 적용 시에 사용
+        // response.setHeader("Refresh", refreshToken);
+
+        int maxAge = 60 * jwtTokenizer.getRefreshTokenExpirationMinutes();
+        Cookie cookie = new Cookie("Refresh", refreshToken);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
 
         this.getSuccessHandler().onAuthenticationSuccess(request, response, authResult);
     }


### PR DESCRIPTION
Refresh Token 전송 방법을 쿠키로 변경하였고 Postman으로 테스트까지 하였습니다. Pull 받으셔서 서버에 적용해서 테스트 해보시기 바랍니다.