### PR TITLE
[수정/추가] 이메일 전송시 URL+토큰,  비밀번호 재설정 (2023.03.24 강지은)

### DIFF
--- a/backend/src/main/java/com/mybuddy/email/controller/EmailController.java
+++ b/backend/src/main/java/com/mybuddy/email/controller/EmailController.java
@@ -2,7 +2,10 @@ package com.mybuddy.email.controller;
 
 import com.mybuddy.email.dto.EmailDto;
 import com.mybuddy.email.service.EmailService;
+import com.mybuddy.global.utils.ApiSingleResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,7 +22,12 @@ public class EmailController {
     private final EmailService emailService;
 
     @PostMapping("/password")
-    public void sendEmailForNewPassword(@Valid @RequestBody EmailDto emailDto) throws MessagingException {
-        emailService.sendEmailForPasswordReset(emailDto.getEmail(), "testUrl");
+    public ResponseEntity<ApiSingleResponse> sendEmailForNewPassword(@Valid @RequestBody EmailDto emailDto) throws MessagingException {
+
+        emailService.sendEmailForPasswordReset(emailDto.getEmail());
+
+        ApiSingleResponse response = new ApiSingleResponse(HttpStatus.OK, "이메일이 전송되었습니다.");
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/mybuddy/email/service/EmailService.java
+++ b/backend/src/main/java/com/mybuddy/email/service/EmailService.java
@@ -4,6 +4,6 @@ import javax.mail.MessagingException;
 
 public interface EmailService {
 
-    void sendEmailForPasswordReset(String email, String url) throws MessagingException;
+    void sendEmailForPasswordReset(String toEmail) throws MessagingException;
 
 }

--- a/backend/src/main/java/com/mybuddy/global/auth/config/SecurityConfiguration.java
+++ b/backend/src/main/java/com/mybuddy/global/auth/config/SecurityConfiguration.java
@@ -88,6 +88,8 @@ public class SecurityConfiguration {
 
                                 // Password (Email전송)
                                 .antMatchers(HttpMethod.POST, "/api/*/password").permitAll()
+                                .antMatchers(HttpMethod.POST, "/api/*/new-password").hasRole("USER")
+
 
                                 // Comment, Follower
                                 .anyRequest().authenticated()

--- a/backend/src/main/java/com/mybuddy/global/auth/filter/JwtVerificationFilter.java
+++ b/backend/src/main/java/com/mybuddy/global/auth/filter/JwtVerificationFilter.java
@@ -73,14 +73,25 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
     }
 
     private void setAuthenticationToContext(Map<String, Object> claims) {
-        PrincipalDto principalDto = PrincipalDto.builder()
-                .loginUserId(Long.parseLong(String.valueOf(claims.get("memberId"))))
-                .email((String) claims.get("username"))
-                .build();
+
+        PrincipalDto principalDto;
+
+        if (claims.get("memberId") != null) {
+            principalDto = PrincipalDto.builder()
+                    .loginUserId(Long.parseLong(String.valueOf(claims.get("memberId"))))
+                    .email((String) claims.get("username"))
+                    .build();
+        }
+        else {
+            principalDto = PrincipalDto.builder()
+                    .email((String) claims.get("username"))
+                    .build();
+        }
 
         List<GrantedAuthority> authorities = authorityUtils.createAuthorities((List) claims.get("roles"));
         Authentication authentication =
-                new UsernamePasswordAuthenticationToken(principalDto, null, authorities);
+                    new UsernamePasswordAuthenticationToken(principalDto, null, authorities);
+
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 }

--- a/backend/src/main/java/com/mybuddy/global/auth/jwt/JwtTokenizer.java
+++ b/backend/src/main/java/com/mybuddy/global/auth/jwt/JwtTokenizer.java
@@ -144,4 +144,23 @@ public class JwtTokenizer {
 
         return key;
     }
+
+
+    public String delegateTokenForNewPassword(Member member) {
+        Map<String, Object> claims = new HashMap<>();
+
+        claims.put("username", member.getEmail());
+        claims.put("roles", member.getRoles());
+
+        String subject = member.getEmail();
+
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + 86400000); // 24시간후 만료 //millisecond 단위 (86400초)
+
+        String base64EncodedSecretKey = encodeBase64SecretKey(getSecretKey());
+
+        String token = generateAccessToken(claims, subject, expiration, base64EncodedSecretKey);
+
+        return token;
+    }
 }

--- a/backend/src/main/java/com/mybuddy/global/config/InterceptorConfig.java
+++ b/backend/src/main/java/com/mybuddy/global/config/InterceptorConfig.java
@@ -10,7 +10,5 @@ public class InterceptorConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new LoginUserInterceptor());
-        //comments는 전체 엔드포인트에 해당해서 인터셉터를 추가해도 되어서 여기다 이런식으로 작성해도 되지만 ->  .addPathPatterns("/api/v1/comments");
-        //일단 주석처리하고, LoginUserInterceptor() 내부에서 처리되도록 작성해 놓았습니다. (2023.03.17 강지은)
     }
 }

--- a/backend/src/main/java/com/mybuddy/global/interceptor/LoginUserInterceptor.java
+++ b/backend/src/main/java/com/mybuddy/global/interceptor/LoginUserInterceptor.java
@@ -20,17 +20,17 @@ public class LoginUserInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
 
-        Long loginUserId;
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-
         if (authentication != null && authentication.getPrincipal() instanceof PrincipalDto) {
+
             PrincipalDto principal = (PrincipalDto) authentication.getPrincipal();
-            loginUserId = principal.getLoginUserId();
 
-
-            request.setAttribute("loginUserId", loginUserId);
-
+            //이메일로 id가 담긴 토큰을 전송하지 않기 때문에 null 체크 로직이 추가되었습니다. (2023.03.24 강지은)
+            if (principal.getLoginUserId() != null) {
+                Long loginUserId = principal.getLoginUserId();
+                request.setAttribute("loginUserId", loginUserId);
+            }
         }
         return HandlerInterceptor.super.preHandle(request, response, handler);
     }

--- a/backend/src/main/java/com/mybuddy/member/controller/PasswordController.java
+++ b/backend/src/main/java/com/mybuddy/member/controller/PasswordController.java
@@ -1,0 +1,35 @@
+package com.mybuddy.member.controller;
+
+import com.mybuddy.global.utils.ApiSingleResponse;
+import com.mybuddy.member.dto.MemberPrivacyDto;
+import com.mybuddy.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class PasswordController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/new-password")
+    public ResponseEntity<ApiSingleResponse> getNewPassword(@Valid @RequestBody MemberPrivacyDto privacyDto,
+                                                            HttpServletRequest request) {
+
+        memberService.createNewPassword(privacyDto.getEmail(), privacyDto.getPassword());
+
+        ApiSingleResponse response = new ApiSingleResponse(HttpStatus.OK, "비밀번호가 변경되었습니다.");
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/mybuddy/member/dto/MemberPrivacyDto.java
+++ b/backend/src/main/java/com/mybuddy/member/dto/MemberPrivacyDto.java
@@ -1,0 +1,27 @@
+package com.mybuddy.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Getter
+public class MemberPrivacyDto {
+
+    @Email
+    @NotBlank
+    private final String email;
+
+    @NotBlank
+    @Pattern(regexp = "^[0-9A-Za-z]{8,20}$",
+            message = "숫자, 영어(대문자 구분)를 포함하여 8 - 20 글자만 사용 가능합니다.")
+    private final String password;
+
+    @Builder
+    public MemberPrivacyDto(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/backend/src/main/java/com/mybuddy/member/service/MemberService.java
+++ b/backend/src/main/java/com/mybuddy/member/service/MemberService.java
@@ -23,4 +23,6 @@ public interface MemberService {
     Member findExistMemberById(Long memberId);
 
     Member findExistMemberByEmail(String email);
+
+    void createNewPassword(String email, String password);
 }

--- a/backend/src/main/java/com/mybuddy/member/service/MemberServiceImpl.java
+++ b/backend/src/main/java/com/mybuddy/member/service/MemberServiceImpl.java
@@ -1,6 +1,5 @@
 package com.mybuddy.member.service;
 
-import com.mybuddy.global.auth.dto.PrincipalDto;
 import com.mybuddy.global.auth.utils.MemberAuthorityUtils;
 
 import com.mybuddy.global.exception.LogicException;
@@ -11,8 +10,6 @@ import com.mybuddy.member.entity.Member;
 import com.mybuddy.member.entity.Member.MemberStatus;
 import com.mybuddy.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -21,7 +18,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.annotation.PostConstruct;
 import java.util.List;
 import java.util.Optional;
 
@@ -140,5 +136,15 @@ public class MemberServiceImpl implements MemberService {
     protected void verifyResourceOwner(Long memberId, Long loginUserId) {
         if (!memberId.equals(loginUserId))
             throw new LogicException(LogicExceptionCode.NOT_RESOURCE_OWNER);
+    }
+
+    @Override
+    public void createNewPassword(String email, String password) {
+
+        Member member = findExistMemberByEmail(email);
+
+        String encryptedPassword = passwordEncoder.encode(password);
+        member.setPassword(encryptedPassword);
+
     }
 }


### PR DESCRIPTION
- 이메일 전송시 토큰을 생성해 버튼 url에 추가했습니다.
- 해당 토큰을 이용해 비밀번호 재설정 요청을 보내면, 정상적으로 변경되는것을 확인했습니다.
- 토큰의 만료기한은 현재 24시간으로 되어있는데 추후 수정될 수 있습니다.