### PR TITLE
[추가] Refresh Token 쿠키에 SameSite=None 추가 (2023.03.24 강지후)

### DIFF
--- a/backend/src/main/java/com/mybuddy/global/auth/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/mybuddy/global/auth/filter/JwtAuthenticationFilter.java
@@ -61,11 +61,8 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         // response.setHeader("Refresh", refreshToken);
 
         int maxAge = 60 * jwtTokenizer.getRefreshTokenExpirationMinutes();
-        Cookie cookie = new Cookie("Refresh", refreshToken);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        cookie.setMaxAge(maxAge);
-        response.addCookie(cookie);
+        response.addHeader("Set-Cookie", "Refresh=" + refreshToken + "; SameSite=None; " +
+                "Max-Age=" + maxAge + "; HttpOnly; Path=/");
 
         this.getSuccessHandler().onAuthenticationSuccess(request, response, authResult);
     }


### PR DESCRIPTION
SameSite=None을 추가했는데 실제로 동작할지는 모르겠습니다. Secure=true로 해줘야 제대로 작동한다는데 저 옵션은 Https를 위한 것이라 저 옵션은 빼고 SameSite에 대한 것만 일단 추가해서 올립니다.