### PR TITLE
[추가] Local용 application.yml profile 추가 (2023.03.25 강지후)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -48,8 +48,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.h2database:h2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	// runtimeOnly 'com.mysql:mysql-connector-j'
-//		implementation 'mysql:mysql-connector-java:8.0.28'
+	runtimeOnly 'com.mysql:mysql-connector-j'
+	// implementation 'mysql:mysql-connector-java:8.0.28'
 
 	//S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'

--- a/backend/src/main/resources/application-h2.yml
+++ b/backend/src/main/resources/application-h2.yml
@@ -1,0 +1,17 @@
+spring:
+  h2:
+    console:
+      enabled: true
+      path: /h2
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true

--- a/backend/src/main/resources/application-mysql.yml
+++ b/backend/src/main/resources/application-mysql.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/mybuddy?serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true
+    username: root
+    password: ${SQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL5Dialect
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,32 +4,10 @@ spring:
       enabled: true
       max-file-size: 10MB
       max-request-size: 10MB
-  h2:
-    console:
-      enabled: true
-      path: /h2
 
-  datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:test
-
-  jpa:
-    show-sql: true
-    hibernate:
-      ddl-auto: create
-    properties:
-      hibernate:
-        format_sql: true
-
-#  docker에 redis 실행시키고 로컬서 사용하는 버젼
   redis:
-    host: localhost
-    port: 6379
-
-#   지후님 docker-compose 버젼
-#  redis:
-#    host: host.docker.internal
-#    port: 6379
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
 
   mail:
     host: smtp.gmail.com
@@ -55,13 +33,11 @@ logging:
         util:
           EC2MetadataUtils: error
 
-
 jwt:
   key: ${JWT_SECRET_KEY}
   access-token-expiration-minutes: 20
   refresh-token-expiration-minutes: 200
 
-#
 cloud:
   aws:
     credentials:


### PR DESCRIPTION
현재 application.yml 파일 설정을 각자 하고 있어서 통일이 안되는 관계로, 이 PR을 올립니다.

application.yml에는 공통 부분이 들어있고, application-h2.yml 및 application-mysql.yml로 나누어 놨으니 필요에 따라 active profile을 변경하여 쓰시면 되고, 환경변수로 되어 있는 부분은 환경변수로 써도 되고 그냥 각자 로컬에서 하드코딩으로 쓰셔도 될 것 같습니다. build.gradle에는 h2와 mysql을 같이 주석처리 없이 열어놨는데, profile을 나눠서 사용하면 빌드도 되고 실행도 되는 것을 확인하였습니다.

PR 확인해보시고 적용해도 되겠다 싶으면 merge가 가능하다고 알려주시기 바랍니다.