### PR TITLE
[추가] 업로드 파일 확장자 제한, 예외처리, 용량 예외처리 (2023.03.26 정다운)

### DIFF
--- a/backend/src/main/java/com/mybuddy/global/advice/GlobalExceptionAdvice.java
+++ b/backend/src/main/java/com/mybuddy/global/advice/GlobalExceptionAdvice.java
@@ -1,6 +1,7 @@
 package com.mybuddy.global.advice;
 
 import com.mybuddy.global.exception.LogicException;
+import com.mybuddy.global.exception.StorageException;
 import com.mybuddy.global.utils.ErrorResponse;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.security.SignatureException;
@@ -14,6 +15,8 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 import javax.validation.ConstraintViolationException;
@@ -85,7 +88,26 @@ public class GlobalExceptionAdvice {
     public ErrorResponse handleMissingServletRequestPartException(
             MissingServletRequestPartException e) {
             
-            final ErrorResponse response = ErrorResponse.of(HttpStatus.BAD_REQUEST,
+        final ErrorResponse response = ErrorResponse.of(HttpStatus.BAD_REQUEST,
+                e.getMessage());
+
+        return response;
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(value = HttpStatus.PAYLOAD_TOO_LARGE)
+    public ErrorResponse handleMultipartExceptionPayloadTooLarge(MaxUploadSizeExceededException e) {
+
+        final ErrorResponse response = ErrorResponse.of(HttpStatus.PAYLOAD_TOO_LARGE,
+                "Maximum upload size exceeded, exceeds its maximum permitted size of 10MB");
+
+        return response;
+    }
+    @ExceptionHandler
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleStorageException(StorageException e) {
+
+        final ErrorResponse response = ErrorResponse.of(HttpStatus.BAD_REQUEST,
                 e.getMessage());
 
         return response;

--- a/backend/src/main/java/com/mybuddy/global/auth/config/SecurityConfiguration.java
+++ b/backend/src/main/java/com/mybuddy/global/auth/config/SecurityConfiguration.java
@@ -102,14 +102,6 @@ public class SecurityConfiguration {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 
-    @Bean
-    public CommonsMultipartResolver multipartResolver() {
-        CommonsMultipartResolver multipartResolver = new CommonsMultipartResolver();
-        multipartResolver.setMaxUploadSizePerFile(10 * 1024 * 1024); // 10MB
-        multipartResolver.setMaxUploadSize(10 * 1024 * 1024); // 10MB
-        multipartResolver.setDefaultEncoding("UTF-8");
-        return multipartResolver;
-    }
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {

--- a/backend/src/main/java/com/mybuddy/global/storage/S3StorageService.java
+++ b/backend/src/main/java/com/mybuddy/global/storage/S3StorageService.java
@@ -14,8 +14,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Date;
-import java.util.UUID;
+import java.util.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -30,7 +29,14 @@ public class S3StorageService implements StorageService {
     @Override
     public String storeImage(MultipartFile multipartFile) {
 
-        String s3FileName = UUID.randomUUID().toString().concat(getFileExtension(multipartFile.getOriginalFilename()));
+        String fileExtension = getFileExtension(multipartFile.getOriginalFilename());
+        ArrayList<String> extensionList = new ArrayList<String>(List.of(".png",".jpg",".gif"));
+
+        if (!extensionList.contains(fileExtension)){
+            throw new StorageException("Wrong file extension(" + fileExtension + ")");
+        }
+
+        String s3FileName = UUID.randomUUID().toString().concat(fileExtension);
 
         try {
             if (multipartFile.isEmpty()) {
@@ -61,7 +67,7 @@ public class S3StorageService implements StorageService {
         try {
             return fileName.substring(fileName.lastIndexOf("."));
         } catch (StringIndexOutOfBoundsException e) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일(" + fileName + ") 입니다.");
+            throw new StorageException("Wrong file extension(" + fileName + ")");
         }
     }
 


### PR DESCRIPTION
업로드 파일 (.png  .jpg  .gif) 로 제한,
이 외에 파일 업로드시 400 bad request 예외 처리,
업로드 파일 용량 yml 파일로도 제한 가능해서 SecurityConfig에 해당 bean 삭제,
업로드 파일 용량 초과시 413 request entity too large 예외처리
해두었습니다.