### PR TITLE
[버그] 친구찾기 이미지 출력 버그 수정 (2023.03.29 정정수)

### DIFF
--- a/frontend/src/Pages/FriendSearchPage.jsx
+++ b/frontend/src/Pages/FriendSearchPage.jsx
@@ -87,10 +87,10 @@ function FriendSearchPage() {
               !!data &&
               data.pages.map(({ data: fetchData }, pageIndex) =>
                 fetchData.map(
-                  ({ memberId, nickname, dogName, photoUrl }, idx) => {
+                  ({ memberId, nickname, dogName, profileUrl }, idx) => {
                     const props = {
                       memberId,
-                      photoUrl,
+                      profileUrl,
                       name:
                         searchOptions.searchType === 'dogName'
                           ? dogName

--- a/frontend/src/components/UI/PostProfileItem/index.jsx
+++ b/frontend/src/components/UI/PostProfileItem/index.jsx
@@ -59,7 +59,7 @@ const Button = styled.button`
 
 function ProfileItem({
   memberId,
-  photoUrl,
+  profileUrl,
   name,
   onClick,
   isLastItem,
@@ -69,7 +69,7 @@ function ProfileItem({
 
   return (
     <ProfileBox ref={ref} data-member-id={memberId}>
-      <ProifleImage src={photoUrl} alt={`${name} 프로필 사진`} />
+      <ProifleImage src={profileUrl} alt={`${name} 프로필 사진`} />
       <ProfileName>
         {name}
         <Button onClick={onClick}>


### PR DESCRIPTION
### 오류 원인
- 이슈번호: #208 
- home 피드의 게시글 리스트 아이템과 분리 과정에서 잘 못된 필드명 설정으로 이미지 주소를 정상적으로 설정하지 못함

### 조치
- photoUrl -> profileUrl로 변수 및 파라미터명 변경
