### PR TITLE
[버그] 글자 수에 따른 댓글 영역 벗어남 버그 수정 (2023.03.29 정정수)

### DIFF
--- a/frontend/src/Pages/FriendSearchPage.jsx
+++ b/frontend/src/Pages/FriendSearchPage.jsx
@@ -87,10 +87,10 @@ function FriendSearchPage() {
               !!data &&
               data.pages.map(({ data: fetchData }, pageIndex) =>
                 fetchData.map(
-                  ({ memberId, nickname, dogName, photoUrl }, idx) => {
+                  ({ memberId, nickname, dogName, profileUrl }, idx) => {
                     const props = {
                       memberId,
-                      photoUrl,
+                      profileUrl,
                       name:
                         searchOptions.searchType === 'dogName'
                           ? dogName

--- a/frontend/src/components/Comments/CommentsForm.jsx
+++ b/frontend/src/components/Comments/CommentsForm.jsx
@@ -1,11 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useQueryClient } from 'react-query';
 
-import useInputs from '../../hooks/useInputs';
-import useCreateComments from '../../hooks/comments/useCreateComments';
-
 import { ReactComponent as IconComments } from '../../assets/icons/icon-comments.svg';
+import useCreateComments from '../../hooks/comments/useCreateComments';
 import useAxiosErrorModal from '../../hooks/useAxiosErrorModal';
 
 const Form = styled.form`
@@ -25,7 +23,7 @@ const Form = styled.form`
   }
 `;
 
-const Input = styled.textarea`
+const Input = styled.input`
   width: 100%;
   padding-left: 12px;
   font-size: var(--font-size-16);
@@ -34,22 +32,41 @@ const Input = styled.textarea`
 
   resize: none;
   height: 23px;
+
+  /* :invalid {
+    position: absolute;
+    bottom: 100%;
+    left: 0;
+  } */
+`;
+
+const Button = styled.button`
+  margin-left: -3px;
+  height: inherit;
 `;
 
 const StyledIconComments = styled(IconComments)`
   justify-items: flex-end;
   align-self: end;
   height: inherit;
-  margin-left: -3px;
 `;
 
 function CommentsForm({ bulletinId }) {
   const queryClient = useQueryClient();
-  const onError = useAxiosErrorModal(true);
+  const onError = useAxiosErrorModal();
 
-  const [{ commentContent }, onChange, reset] = useInputs({
-    commentContent: '',
-  });
+  const [commentContent, setCommentContent] = useState('');
+
+  const handleChange = event => {
+    const { value } = event.target;
+    if (value.length > 120) {
+      event.target.setCustomValidity('최대 120자까지만 입력하실 수 있습니다!');
+    } else {
+      event.target.setCustomValidity('');
+    }
+
+    setCommentContent(value);
+  };
 
   const { mutateAsync: commentMutate } = useCreateComments({
     onSuccess: () => {
@@ -65,6 +82,17 @@ function CommentsForm({ bulletinId }) {
     });
   };
 
+  const handleSubmit = async event => {
+    if (commentContent.length === 0 || commentContent.length > 120) {
+      return;
+    }
+
+    event.preventDefault();
+
+    await handleCommentSubmit(commentContent);
+    setCommentContent('');
+  };
+
   const handleKetDown = async event => {
     if (event.nativeEvent.isComposing) {
       // isComposing 이 true 이면조합 중이므로 동작을 막는다.
@@ -76,24 +104,24 @@ function CommentsForm({ bulletinId }) {
     }
 
     if (event.key === 'Enter') {
-      event.preventDefault();
-
-      await handleCommentSubmit(commentContent);
-      reset();
+      handleSubmit(event);
     }
   };
 
   return (
     <Form>
-      <StyledIconComments />
+      <Button onClick={handleSubmit}>
+        <StyledIconComments />
+      </Button>
       <Input
         value={commentContent}
         name="commentContent"
         id="commentContent"
         placeholder="댓글 달기!"
-        onChange={onChange}
+        onChange={handleChange}
         onKeyDown={handleKetDown}
         row={1}
+        required
       />
     </Form>
   );

--- a/frontend/src/components/Comments/CommentsItem.jsx
+++ b/frontend/src/components/Comments/CommentsItem.jsx
@@ -63,7 +63,7 @@ const ContentStlye = css`
 
 const Content = styled.div`
   ${ContentStlye}
-  max-width: 280px;
+
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: normal;
@@ -81,8 +81,6 @@ const ContentEdit = styled.textarea`
   padding: 6px;
   resize: none;
   line-height: 20px;
-  overflow: hidden;
-  height: auto;
 `;
 
 const SeeMoreSvg = styled(IconSeeMore)`
@@ -132,6 +130,15 @@ const MenuButton = styled.button`
     color: ${({ showSeeMoreMenu }) =>
       showSeeMoreMenu ? 'var(--color-secondary)' : 'inherit'};
   }
+`;
+
+const EditMenuWrapper = styled.div`
+  width: 24px;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-self: center;
 `;
 
 function CommentsItem({
@@ -215,14 +222,16 @@ function CommentsItem({
       ) : (
         <Fragment>
           <Content>{commentContent}</Content>
-          {displayEditMenu ? (
-            <MenuButton
-              showSeeMoreMenu={showSeeMoreMenu}
-              onClick={handleSeeMoreButton}
-            >
-              <SeeMoreSvg />
-            </MenuButton>
-          ) : null}
+          <EditMenuWrapper>
+            {displayEditMenu ? (
+              <MenuButton
+                showSeeMoreMenu={showSeeMoreMenu}
+                onClick={handleSeeMoreButton}
+              >
+                <SeeMoreSvg />
+              </MenuButton>
+            ) : null}
+          </EditMenuWrapper>
         </Fragment>
       )}
 

--- a/frontend/src/components/Comments/CommentsItem.jsx
+++ b/frontend/src/components/Comments/CommentsItem.jsx
@@ -12,7 +12,7 @@ import useModal from '../../hooks/useModal';
 const StyledCommenstItem = styled(Card)`
   width: 100%;
   height: 100%;
-  flex: 1 1 0;
+
   min-height: 80px;
   padding: 10px;
   /* transform: translate(-0.25rem, -0.25rem); */
@@ -63,15 +63,26 @@ const ContentStlye = css`
 
 const Content = styled.div`
   ${ContentStlye}
+  max-width: 280px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: normal;
+  text-align: left;
+  word-wrap: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
 `;
 
 const ContentEdit = styled.textarea`
   ${ContentStlye}
   border: var(--border);
-  height: 100%;
+  height: auto;
   padding: 6px;
   resize: none;
   line-height: 20px;
+  overflow: hidden;
+  height: auto;
 `;
 
 const SeeMoreSvg = styled(IconSeeMore)`
@@ -105,7 +116,7 @@ const EditCompleteSvg = styled(IconCheck)`
 const EditMenu = styled(EditAndRemoveButton)`
   position: absolute;
   right: -9px;
-  bottom: -40px;
+  bottom: calc(50% - 80px);
   z-index: 999;
 `;
 
@@ -192,6 +203,7 @@ function CommentsItem({
             value={newContent}
             name="newContent"
             onChange={handleChange}
+            row={3}
           />
           <MenuButton onClick={handleCompleteClick}>
             <EditCompleteSvg />

--- a/frontend/src/components/UI/PostProfileItem/index.jsx
+++ b/frontend/src/components/UI/PostProfileItem/index.jsx
@@ -59,7 +59,7 @@ const Button = styled.button`
 
 function ProfileItem({
   memberId,
-  photoUrl,
+  profileUrl,
   name,
   onClick,
   isLastItem,
@@ -69,7 +69,7 @@ function ProfileItem({
 
   return (
     <ProfileBox ref={ref} data-member-id={memberId}>
-      <ProifleImage src={photoUrl} alt={`${name} 프로필 사진`} />
+      <ProifleImage src={profileUrl} alt={`${name} 프로필 사진`} />
       <ProfileName>
         {name}
         <Button onClick={onClick}>


### PR DESCRIPTION
### 오류 원인
- 이슈: #210 
- 댓글 영역의 최대 너비를 지정하지 않아 내용이 영역을 벗어나는 현상 발생
- 그에 따른 수정/삭제하기 메뉴 영역 위치 깨짐현상 발생

### 조치
- 최대 너비 지정
- 최대 row 3줄 까지 출력하고, 댓글 전체 너비가 반응형으로 줄어든 경우 (...) 생략 표시하도록 수정
- 댓글 작성 form의 최대 글자수 120자로 제한 -> 현재 댓글 영역의 최대 너비일때 3줄의 글자수
- 수정/삭제하기 메뉴 반응형으로 수정