### PR TITLE
[수정] 배포 환경에 맞춰 9시간 시차 적용 (2023.03.29 정정수)

### DIFF
--- a/frontend/src/utils/time.js
+++ b/frontend/src/utils/time.js
@@ -14,6 +14,8 @@ export function getBetweenTime(start, end, milliSeconds) {
 
 export function elapsedTime(date) {
   const compareTime = new Date(date);
+  compareTime.setHours(compareTime.getHours() + 9);
+
   const nowTime = new Date();
 
   const formatter = new Intl.RelativeTimeFormat('ko', {


### PR DESCRIPTION
개발내용
- 현재 서버 기준시가 영국시로 되어있어, +9시간을 더하여 home feed에 출력되도록 수정