### PR TITLE
[추가/수정] 탈퇴 회원 관련 로그인 및 팔로우 추가 및 수정

### DIFF
--- a/backend/src/main/java/com/mybuddy/follow/service/FollowServiceImpl.java
+++ b/backend/src/main/java/com/mybuddy/follow/service/FollowServiceImpl.java
@@ -51,7 +51,8 @@ public class FollowServiceImpl implements FollowService {
         // LoginUser가 followeeId로 저장되어 있는 리스트 불러오기.
         List<Follow> followList = followRepository.findFollowListByFolloweeId(loginUserId);
         List<Member> followerList = followList.stream()
-                .map(following -> memberService.getMember(following.getFollower().getMemberId()))
+                .map(following -> memberService.getAllStatusMember(following.getFollower().getMemberId()))
+                .filter(member -> member.getMemberStatus() == Member.MemberStatus.ACTIVE)
                 .sorted(Comparator.comparingLong(Member::getMemberId).reversed())
                 .collect(Collectors.toList());
 
@@ -64,7 +65,8 @@ public class FollowServiceImpl implements FollowService {
         // LoginUser가 followerId로 저장되어 있는 리스트 불러오기.
         List<Follow> followList = followRepository.findFollowListByFollowerId(loginUserId);
         List<Member> followeeList = followList.stream()
-                .map(following -> memberService.getMember(following.getFollowee().getMemberId()))
+                .map(following -> memberService.getAllStatusMember(following.getFollowee().getMemberId()))
+                .filter(member -> member.getMemberStatus() == Member.MemberStatus.ACTIVE)
                 .sorted(Comparator.comparingLong(Member::getMemberId).reversed())
                 .collect(Collectors.toList());
 

--- a/backend/src/main/java/com/mybuddy/global/auth/config/SecurityConfiguration.java
+++ b/backend/src/main/java/com/mybuddy/global/auth/config/SecurityConfiguration.java
@@ -8,6 +8,7 @@ import com.mybuddy.global.auth.handler.MemberAuthenticationFailureHandler;
 import com.mybuddy.global.auth.handler.MemberAuthenticationSuccessHandler;
 import com.mybuddy.global.auth.jwt.JwtTokenizer;
 import com.mybuddy.global.auth.utils.MemberAuthorityUtils;
+import com.mybuddy.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -39,6 +40,8 @@ public class SecurityConfiguration {
     private final MemberAuthorityUtils authorityUtils;
 
     private final RedisTemplate<String, String> redisTemplate;
+
+    private final MemberRepository memberRepository;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -133,7 +136,7 @@ public class SecurityConfiguration {
             AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
 
             JwtAuthenticationFilter jwtAuthenticationFilter =
-                    new JwtAuthenticationFilter(authenticationManager, jwtTokenizer, redisTemplate);
+                    new JwtAuthenticationFilter(authenticationManager, jwtTokenizer, redisTemplate, memberRepository);
             jwtAuthenticationFilter.setFilterProcessesUrl("/api/v1/auth/login");
             jwtAuthenticationFilter.setAuthenticationSuccessHandler(new MemberAuthenticationSuccessHandler());
             jwtAuthenticationFilter.setAuthenticationFailureHandler(new MemberAuthenticationFailureHandler());

--- a/backend/src/main/java/com/mybuddy/member/service/MemberService.java
+++ b/backend/src/main/java/com/mybuddy/member/service/MemberService.java
@@ -12,6 +12,8 @@ public interface MemberService {
 
     Member getMember(Long memberId);
 
+    Member getAllStatusMember(Long memberId);
+
     Page<Member> getMemberList(int page, int size);
 
     void deleteMember(Long memberId, long loginUserId);

--- a/backend/src/main/java/com/mybuddy/member/service/MemberServiceImpl.java
+++ b/backend/src/main/java/com/mybuddy/member/service/MemberServiceImpl.java
@@ -75,6 +75,11 @@ public class MemberServiceImpl implements MemberService {
         return findExistMemberById(memberId);
     }
 
+    @Override
+    public Member getAllStatusMember(Long memberId) {
+        return memberRepository.findById(memberId).get();
+    }
+
     @Override // ADMIN 조회용으로 탈퇴 회원의 정보까지 모두 조회 가능.
     public Page<Member> getMemberList(int page, int size) {
         return memberRepository.findAll(PageRequest.of(page, size,

--- a/backend/src/test/java/com/mybuddy/follow/service/FollowServiceTest.java
+++ b/backend/src/test/java/com/mybuddy/follow/service/FollowServiceTest.java
@@ -70,7 +70,7 @@ public class FollowServiceTest {
 
         given(followRepository.findFollowListByFolloweeId(Mockito.anyLong()))
                 .willReturn(followList);
-        given(memberService.getMember(Mockito.anyLong()))
+        given(memberService.getAllStatusMember(Mockito.anyLong()))
                 .willReturn(obtainedMember);
 
         // When
@@ -92,7 +92,7 @@ public class FollowServiceTest {
 
         given(followRepository.findFollowListByFollowerId(Mockito.anyLong()))
                 .willReturn(followList);
-        given(memberService.getMember(Mockito.anyLong()))
+        given(memberService.getAllStatusMember(Mockito.anyLong()))
                 .willReturn(obtainedMember);
 
         // When


### PR DESCRIPTION
현재 탈퇴 회원은 로그인이 되지 않지만 FE에 에러 메시지가 전달되지 않고 500 코드만 보내주는 상태입니다. 이것은 추후에 수정이 될 것입니다.