### PR TITLE
[버그] 프로필 이미지 초기값으로 설정 (2023.03.30 정정수)

### DIFF
--- a/frontend/src/hooks/useImageError.js
+++ b/frontend/src/hooks/useImageError.js
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react';
 function useImageError(src) {
   const defaultProfileUrl =
     'https://cdn-icons-png.flaticon.com/512/1130/1130933.png?w=2000&t=st=1680005925~exp=1680006525~hmac=8e8077d62e937c5ca56e24827f856a436440d7fb244eff53af34fffddc88d213';
-  const [imgSrc, setImgSrc] = useState(src);
+  const [imgSrc, setImgSrc] = useState(src || defaultProfileUrl);
   const [error, setError] = useState(false);
 
   const handleErrorImage = useCallback(() => {


### PR DESCRIPTION
개발 내용
- 이슈: #217
- 프로필 url이 null인 경우 처리되지 않는 버그현상
- null인경우 기보이미지로 설정하도록 수정