### PR TITLE
[수정] 게시글 삭제시 리프레시, 프로필 이름 클릭시 친구페이지 이동 (2023.03.30 정정수)

### DIFF
--- a/frontend/src/components/PostDetail/PostDetailnfo.jsx
+++ b/frontend/src/components/PostDetail/PostDetailnfo.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import useImageError from '../../hooks/useImageError';
+import useModal from '../../hooks/useModal';
 
 import UserName from '../UI/UserName';
 
@@ -42,14 +44,24 @@ const Picture = styled.img`
   width: inherit;
 `;
 
-function PostDetailnfo({ profileUrl, dogName, nickname, photoUrl, children }) {
+function PostDetailnfo({
+  profileUrl,
+  dogName,
+  nickname,
+  photoUrl,
+  memberId,
+  children,
+}) {
   const [src, handleErrorImage] = useImageError(profileUrl);
+  const { closeAllModal } = useModal();
 
   return (
     <Container>
       <Profile>
         <Avatar src={src} onError={handleErrorImage} alt="프로필 사진" />
-        <UserName dogName={dogName} nickname={nickname} />
+        <Link to={`/user/${memberId}`} onClick={() => closeAllModal()}>
+          <UserName dogName={dogName} nickname={nickname} />
+        </Link>
       </Profile>
       <Picture src={photoUrl} alt="게시글 사진" />
       {children}

--- a/frontend/src/components/PostDetail/index.jsx
+++ b/frontend/src/components/PostDetail/index.jsx
@@ -86,6 +86,7 @@ function PostDetail({ userId, bulletinId, onClose }) {
   const { mutateAsync: deleteMutate } = useDeleteBulletinPost({
     onSuccess: () => {
       queryClient.removeQueries(queryKey);
+      queryClient.invalidateQueries('feeds');
       closeAllModal();
 
       openModal(

--- a/frontend/src/components/PostDetail/index.jsx
+++ b/frontend/src/components/PostDetail/index.jsx
@@ -170,6 +170,7 @@ function PostDetail({ userId, bulletinId, onClose }) {
           dogName={dogName}
           nickname={nickname}
           photoUrl={photoUrl}
+          memberId={memberId}
         >
           <InfoContainer>
             <PostDetailHeart

--- a/frontend/src/utils/time.js
+++ b/frontend/src/utils/time.js
@@ -14,10 +14,7 @@ export function getBetweenTime(start, end, milliSeconds) {
 
 export function elapsedTime(date) {
   const compareTime = new Date(date);
-  console.log(compareTime);
   compareTime.setHours(compareTime.getHours() + 9);
-
-  console.log(compareTime);
 
   const nowTime = new Date();
 


### PR DESCRIPTION
### 개발내용
- 이슈 
  - #229
  - #230 
- 게시글 상세의 프로필 이름 클릭시 상세이동
- 삭제시 게시글 리스트 리패칭하도록 수정