### PR TITLE
[버그] 홈(피드) 이미지 하단 빈공간 제거, 높이 수정 (2023.04.01 정정수)

### DIFF
--- a/frontend/src/components/UI/PostItem/index.jsx
+++ b/frontend/src/components/UI/PostItem/index.jsx
@@ -29,17 +29,14 @@ const ItemBox = styled.li`
 
 const PostBody = styled.section`
   cursor: pointer;
-  height: calc(100% - 43px);
-
-  @media (max-width: 1363px) {
-    height: calc(100% - 33px);
-  }
+  height: calc(100% - 45px);
 `;
 
 const PostImage = styled.img`
   width: 100%;
   height: 300px;
   min-height: 300px;
+  vertical-align: bottom;
   object-fit: cover;
 
   @media (max-width: 1363px) {
@@ -106,10 +103,11 @@ const PostFooter = styled.section`
   justify-content: space-between;
   align-items: center;
   padding: 11px 10px 10px 12px;
+  height: 45px;
 
   @media (max-width: 1363px) {
     font-size: 13px;
-    padding: 8px 6px;
+    padding: 8px;
   }
 `;
 

--- a/frontend/src/components/UI/PostItem/index.jsx
+++ b/frontend/src/components/UI/PostItem/index.jsx
@@ -23,7 +23,7 @@ const ItemBox = styled.li`
   }
 
   @media (max-width: 1363px) {
-    height: 400px;
+    height: 410px;
   }
 `;
 
@@ -67,6 +67,7 @@ const PostBox = styled.div`
 const ContentBox = styled.p`
   line-height: 1.4rem;
   padding-bottom: 12px;
+  height: 72px;
 
   width: 100%;
   display: inline-block;

--- a/frontend/src/components/UI/PostList/index.jsx
+++ b/frontend/src/components/UI/PostList/index.jsx
@@ -15,7 +15,7 @@ const StyledPostList = styled.ul`
 
   @media (max-width: 1363px) {
     grid-template-columns: repeat(auto-fill, 280px);
-    grid-gap: 20px 40px;
+    grid-gap: 32px 40px;
     padding: 0 30px;
   }
 `;


### PR DESCRIPTION
### 이슈
- 관련 이슈: #246 
- 변경 적용한 CSS에서 게시글이미지는 공백 생김 현상 발생하여 제거
- card 영역 높이 수정