### PR TITLE
[수정] 게시물 피드 조회시 로그인 유저 게시물까지 조회, admin계정 조회 버그 수정 (2023.04.02 정다운)

### DIFF
--- a/backend/src/main/java/com/mybuddy/bulletin_post/repository/BulletinPostCustomRepository.java
+++ b/backend/src/main/java/com/mybuddy/bulletin_post/repository/BulletinPostCustomRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface BulletinPostCustomRepository {
 
-    Page<BulletinPost> findAllFollowingPostsByMemberId(List<Follow> meAsFollowerList, PageRequest pageRequest);
+    Page<BulletinPost> findAllFollowingPostsByMemberId(Long loginUserId, List<Follow> meAsFollowerList, PageRequest pageRequest);
 
     Page<BulletinPost> findByAmenityId(Long amenityId, PageRequest pageRequest);
 

--- a/backend/src/main/java/com/mybuddy/bulletin_post/repository/BulletinPostCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/mybuddy/bulletin_post/repository/BulletinPostCustomRepositoryImpl.java
@@ -28,7 +28,7 @@ public class BulletinPostCustomRepositoryImpl implements BulletinPostCustomRepos
 
     private final JPAQueryFactory queryFactory;
 
-    public Page<BulletinPost> findAllFollowingPostsByMemberId(List<Follow> meAsFollowerList, PageRequest pageRequest) {
+    public Page<BulletinPost> findAllFollowingPostsByMemberId(Long loginUserId, List<Follow> meAsFollowerList, PageRequest pageRequest) {
         QBulletinPost bulletinPost = QBulletinPost.bulletinPost;
         List<BulletinPost> posts = new ArrayList<>();
 
@@ -39,6 +39,7 @@ public class BulletinPostCustomRepositoryImpl implements BulletinPostCustomRepos
         List<Long> followees = meAsFollowerList.stream()
                 .map(followee -> followee.getFollowee().getMemberId())
                 .collect(Collectors.toList());
+        followees.add(loginUserId);
 
         //날짜 기준 내림차순 정렬
         QueryResults<BulletinPost> queryResults = queryFactory

--- a/backend/src/main/java/com/mybuddy/bulletin_post/service/BulletinPostService.java
+++ b/backend/src/main/java/com/mybuddy/bulletin_post/service/BulletinPostService.java
@@ -93,7 +93,7 @@ public class BulletinPostService {
         if (loginUserId != null) {
             List<Follow> meAsFollowerList = memberService.getMember(loginUserId).getMeAsFollowerList();
 
-            Page<BulletinPost> result = bulletinPostRepository.findAllFollowingPostsByMemberId(meAsFollowerList, pageRequest);
+            Page<BulletinPost> result = bulletinPostRepository.findAllFollowingPostsByMemberId(loginUserId, meAsFollowerList, pageRequest);
 
             //게시물이 없으면 비로그인 유저 피드와 같은 결과 나오도록 if 필터
             if (!result.isEmpty())

--- a/backend/src/main/java/com/mybuddy/search/mapper/SearchMapper.java
+++ b/backend/src/main/java/com/mybuddy/search/mapper/SearchMapper.java
@@ -1,11 +1,15 @@
 package com.mybuddy.search.mapper;
 
+import com.mybuddy.bulletin_post.dto.BulletinPostDto;
 import com.mybuddy.member.entity.Member;
 import com.mybuddy.search.dto.SearchMemberResponseDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingConstants;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface SearchMapper {
@@ -25,5 +29,23 @@ public interface SearchMapper {
         return responseDto;
     };
 
-    List<SearchMemberResponseDto> membersToSearchResponseDtos(List<Member> members);
+
+    default List<SearchMemberResponseDto> membersToSearchResponseDtos(List<Member> members) {
+        if (members == null) {
+            return null;
+        }
+
+        List<SearchMemberResponseDto> list = new ArrayList<SearchMemberResponseDto>(members.size());
+        for (Member member : members) {
+            list.add(memberToSearchResponseDto(member));
+        }
+
+        List<SearchMemberResponseDto> result = list.stream()
+                .sorted(Comparator.comparingLong(
+                        SearchMemberResponseDto::getMemberId).reversed())
+                .collect(Collectors.toList());
+
+        return result;
+    }
+
 }

--- a/backend/src/main/java/com/mybuddy/search/repository/SearchCustomRepository.java
+++ b/backend/src/main/java/com/mybuddy/search/repository/SearchCustomRepository.java
@@ -1,0 +1,12 @@
+package com.mybuddy.search.repository;
+
+import com.mybuddy.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+public interface SearchCustomRepository {
+    Page<Member> findByNicknameExceptAdmin(String keyword, PageRequest pageRequest);
+
+    Page<Member> findByDogNameExceptAdmin(String keyword, PageRequest pageRequest);
+
+}

--- a/backend/src/main/java/com/mybuddy/search/repository/SearchCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/mybuddy/search/repository/SearchCustomRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.mybuddy.search.repository;
+
+import com.mybuddy.member.entity.Member;
+import com.mybuddy.member.entity.QMember;
+import com.querydsl.core.QueryResults;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@RequiredArgsConstructor
+public class SearchCustomRepositoryImpl implements SearchCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Member> findByNicknameExceptAdmin(String keyword, PageRequest pageRequest) {
+        QMember member = QMember.member;
+
+        QueryResults<Member> queryResults = queryFactory
+                .selectFrom(member)
+                .where(member.nickname.containsIgnoreCase(keyword)
+                        .and(member.memberId.ne(1L)))
+                .offset(pageRequest.getOffset())
+                .limit(pageRequest.getPageSize())
+                .orderBy(member.memberId.desc())
+                .fetchResults();
+
+        return new PageImpl<>(queryResults.getResults(), pageRequest, queryResults.getTotal());
+    }
+
+    @Override
+    public Page<Member> findByDogNameExceptAdmin(String keyword, PageRequest pageRequest) {
+        QMember member = QMember.member;
+
+        QueryResults<Member> queryResults = queryFactory
+                .selectFrom(member)
+                .where(member.dogName.containsIgnoreCase(keyword)
+                        .and(member.memberId.ne(1L)))
+                .offset(pageRequest.getOffset())
+                .limit(pageRequest.getPageSize())
+                .orderBy(member.memberId.desc())
+                .fetchResults();
+
+        return new PageImpl<>(queryResults.getResults(), pageRequest, queryResults.getTotal());
+    }
+
+
+}

--- a/backend/src/main/java/com/mybuddy/search/repository/SearchRepository.java
+++ b/backend/src/main/java/com/mybuddy/search/repository/SearchRepository.java
@@ -5,11 +5,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SearchRepository extends JpaRepository<Member, Long> {
+public interface SearchRepository extends JpaRepository<Member, Long>, SearchCustomRepository {
 
-    Page<Member> findByNicknameContaining(String keyword, PageRequest pageRequest);
+//    Page<Member> findByNicknameContaining(String keyword, PageRequest pageRequest);
 
-    Page<Member> findByDogNameContaining(String keyword, PageRequest pageRequest);
+//    Page<Member> findByDogNameContaining(String keyword, PageRequest pageRequest);
 
 
 }

--- a/backend/src/main/java/com/mybuddy/search/service/SearchService.java
+++ b/backend/src/main/java/com/mybuddy/search/service/SearchService.java
@@ -20,10 +20,10 @@ public class SearchService {
         PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "memberId"));
 
         if (type.equals("nickname")) {
-            return searchRepository.findByNicknameContaining(keyword, pageRequest);
+            return searchRepository.findByNicknameExceptAdmin(keyword, pageRequest);
         }
         else if (type.equals("dogName")) {
-            return searchRepository.findByDogNameContaining(keyword, pageRequest);
+            return searchRepository.findByDogNameExceptAdmin(keyword, pageRequest);
         }
         else throw new LogicException(LogicExceptionCode.TYPE_NOT_FOUND);
 


### PR DESCRIPTION
로그인 유저 게시물 피드 조회시 자신의 게시물까지 조회 가능하도록 수정했습니다.
회원 검색시 admin 계정 조회 가능하던 버그 admin 조회 불가능하도록 (memberId 1 조회 불가능하도록) 수정해두었습니다.