### PR TITLE
[기타] build.gradle의 앱 버전 1.0.0으로 수정 (2023.04.02 강지후)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = 'com.mybuddy'
-version = '0.0.1-SNAPSHOT'
+version = '1.0.0'
 sourceCompatibility = '11'
 
 repositories {


### PR DESCRIPTION
버전을 1.0.0으로 수정하였습니다.

빌드 해보니 버전이 알맞게 나오는 것도 확인하였습니다.