### PR TITLE
[버그] 마이페이지 장소 응답에서, 게시물에 장소 없는 경우를 위한 Null 필터링 (2023.04.03 강지은)

### DIFF
--- a/backend/src/main/java/com/mybuddy/member/mapper/MemberMapper.java
+++ b/backend/src/main/java/com/mybuddy/member/mapper/MemberMapper.java
@@ -39,6 +39,7 @@ public interface MemberMapper {
 
         List<AmenityForMyPageResponseDto> amenityForMyPageResponseDtos =
                 member.getBulletinPosts().stream()
+                        .filter(bulletinPost -> bulletinPost.getAmenity() != null)
                         .map(bulletinPost -> {
                             AmenityForMyPageResponseDto amenityForMyPageResponseDto =
                                     AmenityForMyPageResponseDto.builder()


### PR DESCRIPTION
- 특정 유저에게서 마이페이지 500에러가 발생하였고, AmenityResponseDtos 생성중 Exception을 뱉는것을 확인했습니다.


```java
List<AmenityForMyPageResponseDto> amenityForMyPageResponseDtos =
                member.getBulletinPosts().stream()
                        .map(bulletinPost -> {
                            AmenityForMyPageResponseDto amenityForMyPageResponseDto =
                                    AmenityForMyPageResponseDto.builder()
                                            .amenityId(bulletinPost.getAmenity().getAmenityId())
                                            .amenityName(bulletinPost.getAmenity().getAmenityName())
                                            .address(bulletinPost.getAmenity().getAddress())
                                            .photoUrl(bulletinPost.getPhotoUrl())
                                            .postCreatedAt(bulletinPost.getCreatedAt())
                                            .build();
                            return amenityForMyPageResponseDto;
                        })
```

- 위 코드에서 멤버의 모든 게시물을 탐색하는데, 
 게시물에 장소태그가 null일경우 bulletinPost.getAmenity()에서 NPE가 발생할것으로 예상되었고


Null이 아닌경우를 필터링 처리하여 해결했습니다.
