### PR TITLE
[버그] 장소 게시글 리스트 헤더, 클릭 이벤트 오류 수정 (2023.04.03 정정수)

### DIFF
--- a/frontend/src/Pages/AmenityPage.jsx
+++ b/frontend/src/Pages/AmenityPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import PostDetailPage from './PostDetailPage';
 import useModal from '../hooks/useModal';
 
@@ -9,8 +9,8 @@ import PlaceFeedList from '../components/Feeds/PlaceFeedList';
 function AmenityPage() {
   const { closeModal, openModal } = useModal();
   const { amenityId } = useParams();
-  const location = useLocation();
-  const amenityName = location.state?.amenityName;
+  const [searchParams] = useSearchParams();
+  const amenityName = searchParams.get('name');
 
   const handleItemClick = id => {
     openModal(<PostDetailPage bulletinId={id} onClose={closeModal} />);

--- a/frontend/src/Pages/FriendSearchPage.jsx
+++ b/frontend/src/Pages/FriendSearchPage.jsx
@@ -33,8 +33,6 @@ function FriendSearchPage() {
     navigate(`/user/${memberId}`);
   };
 
-  // console.log('1111', searchOptions.searchName, searchOptions.searchType);
-
   const {
     data,
     fetchNextPage,

--- a/frontend/src/components/Feeds/PlaceFeedList.jsx
+++ b/frontend/src/components/Feeds/PlaceFeedList.jsx
@@ -23,20 +23,6 @@ function PlaceFeedList({ amenityId, onClick, colWidth = '300px' }) {
       },
     );
 
-  const handleClick = event => {
-    const $li = event.target.closest('li');
-
-    if (!$li) {
-      return;
-    }
-
-    const { postId } = $li.dataset;
-
-    if (postId) {
-      onClick(postId);
-    }
-  };
-
   useEffect(
     () => () => {
       queryClient.removeQueries('feeds');
@@ -45,7 +31,7 @@ function PlaceFeedList({ amenityId, onClick, colWidth = '300px' }) {
   );
 
   return (
-    <PostList colWidth={colWidth} onClick={handleClick}>
+    <PostList colWidth={colWidth}>
       {!isError &&
         !isLoading &&
         data.pages?.map(({ data: fetchData }, pageIndex) =>
@@ -59,6 +45,7 @@ function PlaceFeedList({ amenityId, onClick, colWidth = '300px' }) {
                 nickname,
                 dogName,
                 createdAt,
+                memberId,
               },
               idx,
             ) => {
@@ -70,6 +57,8 @@ function PlaceFeedList({ amenityId, onClick, colWidth = '300px' }) {
                 nickname,
                 dogName,
                 createdAt,
+                onClick,
+                memberId,
                 isLastItem:
                   pageIndex === Number(data.pages.length) - 1 &&
                   idx === fetchData.length - 1,


### PR DESCRIPTION
### 개발내용
- 장소 게시글 리스트 화면여부 판단 useSearchParams로 수정
- 홈(피드)와 동일하게 유저 네임부분 클릭시 친구 마이페이지 이동으로 수정