### PR TITLE
[버그] UI상 보이는 탈퇴 유저의 정보 제거 (2023.04.04 강지은)

### DIFF
--- a/backend/src/main/java/com/mybuddy/bulletin_post/mapper/BulletinPostMapper.java
+++ b/backend/src/main/java/com/mybuddy/bulletin_post/mapper/BulletinPostMapper.java
@@ -46,6 +46,7 @@ public interface BulletinPostMapper {
         List<CommentResponseDto> commentLists = new ArrayList<>();
         if (bulletinPost.getComments() != null) {
             commentLists = bulletinPost.getComments().stream()
+                    .filter(comment -> comment.getMember().getMemberStatus() != Member.MemberStatus.DELETED)
                     .map(comment -> {
                                 CommentResponseDto commentResponse = new CommentResponseDto(
                                         comment.getCommentId(),
@@ -139,7 +140,8 @@ public interface BulletinPostMapper {
 
         List<BulletinPostDto.ResponseForFeed> list = new ArrayList<BulletinPostDto.ResponseForFeed>(bulletinPosts.size());
         for (BulletinPost bulletinPost : bulletinPosts) {
-            list.add(bulletinPostToBulletinPostResponseForFeedDto(bulletinPost));
+            if (bulletinPost.getMember().getMemberStatus() != Member.MemberStatus.DELETED)
+                list.add(bulletinPostToBulletinPostResponseForFeedDto(bulletinPost));
         }
 
         List<BulletinPostDto.ResponseForFeed> result = list.stream()

--- a/backend/src/main/java/com/mybuddy/bulletin_post/repository/BulletinPostCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/mybuddy/bulletin_post/repository/BulletinPostCustomRepositoryImpl.java
@@ -100,7 +100,8 @@ public class BulletinPostCustomRepositoryImpl implements BulletinPostCustomRepos
         //해당 장소 id를 파라미터로 받는 findFirstPost()메서드가 있다고 가정하고 해당 사진의 URL을 반환하는걸 작성
         QueryResults<BulletinPost> queryResults = queryFactory
                 .selectFrom(bulletinPost)
-                .where(bulletinPost.amenity.amenityId.eq(amenityId))
+                .where(bulletinPost.amenity.amenityId.eq(amenityId)
+                        .and(bulletinPost.member.memberStatus.ne(Member.MemberStatus.DELETED)))
                 .offset(pageRequest.getOffset())
                 .limit(pageRequest.getPageSize())
                 .orderBy(bulletinPost.bulletinPostId.desc())


### PR DESCRIPTION
일차적으로 현재 서비스에서 유저에게 보이는 탈퇴 유저와 관련된 부분을 없애는게 필요하다 판단해 다음과 같은 작업을 진행했습니다.

- 게시글에 달린 댓글 중 탈퇴한 회원의 댓글은 안나오게
- 피드에 탈퇴한 회원의 게시글은 안나오게
- 특정 장소가 태그된 게시물 반환시, 탈퇴한 회원의 게시물 안나오게